### PR TITLE
Fix dependencies used in pre-push githook

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 
 checkstyle {
     toolVersion = '8.29'
+    ignoreFailures = false
+    maxWarnings = 0
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -78,4 +78,8 @@ shadowJar {
     archiveName = 'addressbook.jar'
 }
 
+jacoco {
+    toolVersion = "0.8.7"
+}
+
 defaultTasks 'clean', 'test'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- The current gradle version used is 5.2.1. Mac OS Catalina requires gradle version of at least 6.3 to work. Updated to latest version which is 7.2
- javacoco requires toolVersion 0.8.7 to be compatible
- Add fields in checkstyle to fail build when there are failures or warnings, and disallow push

Fixes #3 