### PR TITLE
Fix prefix table and column header alignment

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -277,12 +277,12 @@ Priorities: High - (must have), Medium - (nice to have), Low -  (unlikely to hav
 
 <table>
   <tr>
-   <th colspan="3"><h3><strong>As a gym manager</strong></h3></th>
+   <th style="text-align: center" colspan="3"><h3><strong>As a gym manager</strong></h3></th>
   </tr>
   <tr>
-    <th><h3><strong>Priority</strong></h3></th>
-    <th><h3><strong>I can...</strong></h3></th>
-    <th><h3><strong>So that...</strong></h3></th>
+    <th style="text-align: center"><h3><strong>Priority</strong></h3></th>
+    <th style="text-align: center"><h3><strong>I can...</strong></h3></th>
+    <th style="text-align: center"><h3><strong>So that...</strong></h3></th>
   </tr>
   <tr>
     <td>HIGH</td>
@@ -545,8 +545,9 @@ Priorities: High - (must have), Medium - (nice to have), Low -  (unlikely to hav
 * **Booking**: A fixed time period (of 1 hour 30 minutes) that a client can use the gym’s facilities
 
 #### Prefix Glossary
+
 | Prefix | Parameter     | Associated with |
-| :----: | :-----------  | :-------------: |
+|:------:|:-------------:|:---------------:|
 | a/     | ADDRESS       | Client          |
 | b/     | BIRTH_DATE    | Client          |
 | c/     | IS_COMPLETED  | Booking         |


### PR DESCRIPTION
Changes:
- Fixed prefix table
- Centered the column headers for the user stories table

See [old](https://ay2122s1-cs2103t-w16-2.github.io/tp/DeveloperGuide.html) vs [new](https://sivayogasubramanian.github.io/tp/DeveloperGuide.html).

Fixes https://github.com/AY2122S1-CS2103T-W16-2/tp/issues/28.