### PR TITLE
Fix deprecated gradle warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ task coverage(type: JacocoReport) {
         })
     }
     reports {
-        html.enabled = true
-        xml.enabled = true
+        html.required = true
+        xml.required = true
     }
 }
 
@@ -77,7 +77,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveName = 'addressbook.jar'
+    archiveFileName = 'addressbook.jar'
 }
 
 jacoco {


### PR DESCRIPTION
Fixes https://github.com/AY2122S1-CS2103T-W16-2/tp/issues/33.

Reviewer to test if the HTML report is generated properly and the jar file (using shadowJar) is also generated and runs properly.