### PR TITLE
Implement test skeleton for booking

### DIFF
--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/exception/NotFoundException.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/exception/NotFoundException.java
@@ -1,7 +1,9 @@
 package ay2122s1_cs2103t_w16_2.btbb.exception;
 
 public class NotFoundException extends Exception {
+    public static final String NOT_FOUND_EXCEPTION_MESSAGE_FORMAT = "The specified %s cannot be found.";
+
     public NotFoundException(String notFoundItem) {
-        super("The specified " + notFoundItem + " cannot be found.");
+        super(String.format(NOT_FOUND_EXCEPTION_MESSAGE_FORMAT, notFoundItem));
     }
 }

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/booking/AddBookingCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/booking/AddBookingCommand.java
@@ -47,4 +47,11 @@ public class AddBookingCommand extends Command {
             throw new CommandException(MESSAGE_CLIENT_NOT_FOUND);
         }
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddBookingCommand // instanceof handles nulls
+                && bookingDescriptor.equals(((AddBookingCommand) other).bookingDescriptor));
+    }
 }

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/BookingDescriptor.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/BookingDescriptor.java
@@ -43,4 +43,22 @@ public class BookingDescriptor {
 
         return new Booking(optionalClient.get());
     }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof BookingDescriptor)) {
+            return false;
+        }
+
+        // state check
+        BookingDescriptor bd = (BookingDescriptor) other;
+
+        return getPhone().equals(bd.getPhone());
+    }
 }

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/Booking.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/Booking.java
@@ -24,7 +24,7 @@ public class Booking {
         this.client = client;
     }
 
-    private Client getClient() {
+    public Client getClient() {
         return client;
     }
 

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingList.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingList.java
@@ -28,6 +28,7 @@ public class UniqueBookingList implements Iterable<Booking> {
     /**
      * Returns true if the list contains an equivalent booking as the given argument.
      *
+     * @param toCheck The booking which is used to check.
      * @return True if the list contains an equivalent booking as the given argument. False otherwise.
      */
     public boolean contains(Booking toCheck) {
@@ -39,6 +40,10 @@ public class UniqueBookingList implements Iterable<Booking> {
      * Replaces the booking {@code target} in the list with {@code editedBooking}.
      * {@code target} must exist in the list.
      * The booking identity of {@code editedBooking} must not be the same as another existing booking in the list.
+     *
+     * @param target The target to change.
+     * @param editedBooking The replacement for target.
+     * @throws NotFoundException If the target cannot be found in the list.
      */
     public void setBooking(Booking target, Booking editedBooking) throws NotFoundException {
         requireAllNonNull(target, editedBooking);
@@ -54,6 +59,9 @@ public class UniqueBookingList implements Iterable<Booking> {
     /**
      * Removes the equivalent booking from the list.
      * The booking must exist in the list.
+     *
+     * @param toRemove The booking that will be used to determine what booking should be removed.
+     * @throws NotFoundException If no matching booking can be found.
      */
     public void remove(Booking toRemove) throws NotFoundException {
         requireNonNull(toRemove);

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingList.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingList.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Iterator;
 import java.util.List;
 
+import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -22,6 +23,43 @@ public class UniqueBookingList implements Iterable<Booking> {
     public void add(Booking toAdd) {
         requireNonNull(toAdd);
         internalList.add(toAdd);
+    }
+
+    /**
+     * Returns true if the list contains an equivalent booking as the given argument.
+     *
+     * @return True if the list contains an equivalent booking as the given argument. False otherwise.
+     */
+    public boolean contains(Booking toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::equals);
+    }
+
+    /**
+     * Replaces the booking {@code target} in the list with {@code editedBooking}.
+     * {@code target} must exist in the list.
+     * The booking identity of {@code editedBooking} must not be the same as another existing booking in the list.
+     */
+    public void setBooking(Booking target, Booking editedBooking) throws NotFoundException {
+        requireAllNonNull(target, editedBooking);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new NotFoundException(Booking.class.getName());
+        }
+
+        internalList.set(index, editedBooking);
+    }
+
+    /**
+     * Removes the equivalent booking from the list.
+     * The booking must exist in the list.
+     */
+    public void remove(Booking toRemove) throws NotFoundException {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new NotFoundException(Booking.class.getName());
+        }
     }
 
     /**

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/CommandExceptionTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/CommandExceptionTest.java
@@ -1,0 +1,20 @@
+package ay2122s1_cs2103t_w16_2.btbb.exception;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class CommandExceptionTest {
+    private static final String COMMAND_EXCEPTION_MESSAGE = "This is a CommandException.";
+
+    @Test
+    public void constructor_throwCommandException_commandExceptionThrown() {
+        assertThrows(CommandException.class, () -> {
+            throw new CommandException(COMMAND_EXCEPTION_MESSAGE);
+        });
+
+        assertThrows(CommandException.class, () -> {
+            throw new CommandException(COMMAND_EXCEPTION_MESSAGE, new Throwable());
+        });
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/DataConversionExceptionTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/DataConversionExceptionTest.java
@@ -1,0 +1,14 @@
+package ay2122s1_cs2103t_w16_2.btbb.exception;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class DataConversionExceptionTest {
+    @Test
+    public void constructor_throwDataConversionException_dataConversionExceptionThrown() {
+        assertThrows(DataConversionException.class, () -> {
+            throw new DataConversionException(new Exception());
+        });
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/IllegalValueExceptionTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/IllegalValueExceptionTest.java
@@ -1,0 +1,20 @@
+package ay2122s1_cs2103t_w16_2.btbb.exception;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class IllegalValueExceptionTest {
+    private static final String ILLEGAL_VALUE_EXCEPTION_MESSAGE = "This is a IllegalValueException.";
+
+    @Test
+    public void constructor_throwIllegalValueException_illegalValueExceptionThrown() {
+        assertThrows(CommandException.class, () -> {
+            throw new CommandException(ILLEGAL_VALUE_EXCEPTION_MESSAGE);
+        });
+
+        assertThrows(CommandException.class, () -> {
+            throw new CommandException(ILLEGAL_VALUE_EXCEPTION_MESSAGE, new Throwable());
+        });
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/NotFoundExceptionTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/NotFoundExceptionTest.java
@@ -1,0 +1,27 @@
+package ay2122s1_cs2103t_w16_2.btbb.exception;
+
+import static ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException.NOT_FOUND_EXCEPTION_MESSAGE_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class NotFoundExceptionTest {
+    private static final String NOT_FOUND_EXCEPTION_INPUT = "random input";
+    private static final String EXPECTED_EXCEPTION_MESSAGE = String.format(
+            NOT_FOUND_EXCEPTION_MESSAGE_FORMAT, NOT_FOUND_EXCEPTION_INPUT
+    );
+
+    @Test
+    public void constructor_throwNotFoundException_notFoundExceptionThrown() {
+        assertThrows(NotFoundException.class, () -> {
+            throw new NotFoundException(NOT_FOUND_EXCEPTION_INPUT);
+        });
+
+        try {
+            throw new NotFoundException(NOT_FOUND_EXCEPTION_INPUT);
+        } catch (NotFoundException e) {
+            assertEquals(e.getMessage(), EXPECTED_EXCEPTION_MESSAGE);
+        }
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/ParseExceptionTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/ParseExceptionTest.java
@@ -1,0 +1,20 @@
+package ay2122s1_cs2103t_w16_2.btbb.exception;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ParseExceptionTest {
+    private static final String PARSE_EXCEPTION_MESSAGE = "This is a ParseException.";
+
+    @Test
+    public void constructor_throwParseException_parseExceptionThrown() {
+        assertThrows(ParseException.class, () -> {
+            throw new ParseException(PARSE_EXCEPTION_MESSAGE);
+        });
+
+        assertThrows(ParseException.class, () -> {
+            throw new ParseException(PARSE_EXCEPTION_MESSAGE, new Throwable());
+        });
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/CommandTestUtil.java
@@ -14,11 +14,13 @@ import java.util.List;
 
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
 import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.BookingDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.NameContainsKeywordsPredicate;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.BookingDescriptorBuilder;
 import ay2122s1_cs2103t_w16_2.btbb.testutil.ClientDescriptorBuilder;
 
 /**
@@ -53,6 +55,8 @@ public class CommandTestUtil {
 
     public static final ClientDescriptor DESC_AMY;
     public static final ClientDescriptor DESC_BOB;
+    public static final BookingDescriptor DESC_BOOKING_AMY;
+    public static final BookingDescriptor DESC_BOOKING_BOB;
 
     static {
         DESC_AMY = new ClientDescriptorBuilder().withName(VALID_NAME_AMY)
@@ -61,6 +65,8 @@ public class CommandTestUtil {
         DESC_BOB = new ClientDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .build();
+        DESC_BOOKING_AMY = new BookingDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        DESC_BOOKING_BOB = new BookingDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
     }
 
     /**

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/booking/AddBookingCommandIntegrationTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/booking/AddBookingCommandIntegrationTest.java
@@ -1,0 +1,46 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.booking;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.BookingDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.Model;
+import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
+import ay2122s1_cs2103t_w16_2.btbb.model.UserPrefs;
+import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.BookingBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.BookingDescriptorBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.ClientBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code AddBookingCommand}.
+ */
+public class AddBookingCommandIntegrationTest {
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_newBooking_success() {
+        Client validClient = new ClientBuilder().build();
+        Booking validBooking = new BookingBuilder().forClient(validClient).build();
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        // A booking cannot be added without the model containing the associated Client.
+        model.addClient(validClient);
+        expectedModel.addClient(validClient);
+        expectedModel.addBooking(validBooking);
+        BookingDescriptor validBookingDescriptor = new BookingDescriptorBuilder(validBooking).build();
+
+        assertCommandSuccess(new AddBookingCommand(validBookingDescriptor), model,
+                String.format(AddBookingCommand.MESSAGE_SUCCESS, validBooking), expectedModel);
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/booking/AddBookingCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/booking/AddBookingCommandTest.java
@@ -1,0 +1,65 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.booking;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.ALICE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.BookingDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.BookingBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.BookingDescriptorBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.stubs.ModelStubAcceptingBookingAdded;
+
+class AddBookingCommandTest {
+    @Test
+    public void constructor_nullBooking_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddBookingCommand(null));
+    }
+
+    @Test
+    public void execute_bookingAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingBookingAdded modelStub = new ModelStubAcceptingBookingAdded();
+        Booking validBooking = new BookingBuilder().forClient(ALICE).build();
+        BookingDescriptor validBookingDescriptor = new BookingDescriptorBuilder(validBooking).build();
+
+        // A booking can only be added if the client exists.
+        modelStub.addClient(ALICE);
+        CommandResult commandResult = new AddBookingCommand(validBookingDescriptor).execute(modelStub);
+
+        assertEquals(String.format(AddBookingCommand.MESSAGE_SUCCESS, validBooking), commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validBooking), modelStub.getBookingsAdded());
+    }
+
+    @Test
+    public void equals() {
+        BookingDescriptor bookingDescriptorForAmy = new BookingDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        BookingDescriptor bookingDescriptorForBob = new BookingDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
+        AddBookingCommand addBookingForAmyCommand = new AddBookingCommand(bookingDescriptorForAmy);
+        AddBookingCommand addBookingForBobCommand = new AddBookingCommand(bookingDescriptorForBob);
+
+        // same object -> returns true
+        assertTrue(addBookingForAmyCommand.equals(addBookingForAmyCommand));
+
+        // same values -> returns true
+        AddBookingCommand addBookingForAmyCommandCopy = new AddBookingCommand(bookingDescriptorForAmy);
+        assertTrue(addBookingForAmyCommand.equals(addBookingForAmyCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addBookingForAmyCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addBookingForAmyCommand.equals(null));
+
+        // different client -> returns false
+        assertFalse(addBookingForAmyCommand.equals(addBookingForBobCommand));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/booking/AddBookingCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/booking/AddBookingCommandTest.java
@@ -31,7 +31,7 @@ class AddBookingCommandTest {
         Booking validBooking = new BookingBuilder().forClient(ALICE).build();
         BookingDescriptor validBookingDescriptor = new BookingDescriptorBuilder(validBooking).build();
 
-        // A booking can only be added if the client exists.
+        // A booking can only be added if the client already exists.
         modelStub.addClient(ALICE);
         CommandResult commandResult = new AddBookingCommand(validBookingDescriptor).execute(modelStub);
 

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandIntegrationTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandIntegrationTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -7,7 +7,6 @@ import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.getTypicalAddr
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.AddClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandTest.java
@@ -1,33 +1,23 @@
 package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.commons.core.GuiSettings;
 import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
-import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
-import ay2122s1_cs2103t_w16_2.btbb.model.Model;
-import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyAddressBook;
-import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyUserPrefs;
-import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
-import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
 import ay2122s1_cs2103t_w16_2.btbb.testutil.ClientBuilder;
 import ay2122s1_cs2103t_w16_2.btbb.testutil.ClientDescriptorBuilder;
-import javafx.collections.ObservableList;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.stubs.ModelStub;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.stubs.ModelStubAcceptingClientAdded;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.stubs.ModelStubWithClient;
 
 public class AddClientCommandTest {
     @Test
@@ -80,137 +70,5 @@ public class AddClientCommandTest {
 
         // different client -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addBooking(Booking booking) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredBookingList(Predicate<Booking> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addClient(Client client) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasClient(Client client) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Optional<Client> getClientByPhone(Phone phone) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteClient(Client target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setClient(Client target, Client editedClient) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Client> getFilteredClientList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredClientList(Predicate<Client> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
-    /**
-     * A Model stub that contains a single client.
-     */
-    private class ModelStubWithClient extends ModelStub {
-        private final Client client;
-
-        ModelStubWithClient(Client client) {
-            requireNonNull(client);
-            this.client = client;
-        }
-
-        @Override
-        public boolean hasClient(Client client) {
-            requireNonNull(client);
-            return this.client.isSameClient(client);
-        }
-    }
-
-    /**
-     * A Model stub that always accept the client being added.
-     */
-    private class ModelStubAcceptingClientAdded extends ModelStub {
-        final ArrayList<Client> clientsAdded = new ArrayList<>();
-
-        @Override
-        public boolean hasClient(Client client) {
-            requireNonNull(client);
-            return clientsAdded.stream().anyMatch(client::isSameClient);
-        }
-
-        @Override
-        public void addClient(Client client) {
-            requireNonNull(client);
-            clientsAdded.add(client);
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
-        }
     }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandTest.java
@@ -34,7 +34,7 @@ public class AddClientCommandTest {
         CommandResult commandResult = new AddClientCommand(validClientDescriptor).execute(modelStub);
 
         assertEquals(String.format(AddClientCommand.MESSAGE_SUCCESS, validClient), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validClient), modelStub.clientsAdded);
+        assertEquals(Arrays.asList(validClient), modelStub.getClientsAdded());
     }
 
     @Test

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
 import static java.util.Objects.requireNonNull;
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.GuiSettings;
 import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.AddClientCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/DeleteClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/DeleteClientCommandTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
 import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.DeleteClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
 import ay2122s1_cs2103t_w16_2.btbb.model.UserPrefs;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/EditClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/EditClientCommandTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_AMY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_BOB;
@@ -18,8 +18,6 @@ import org.junit.jupiter.api.Test;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
 import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.EditClientCommand;
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.ListClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/FindClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/FindClientCommandTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_CLIENTS_LISTED_OVERVIEW;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -15,7 +15,6 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.FindClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
 import ay2122s1_cs2103t_w16_2.btbb.model.UserPrefs;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/ListClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/ListClientCommandTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.showClientAtIndex;
@@ -8,7 +8,6 @@ import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_FIRST_CL
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.ListClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
 import ay2122s1_cs2103t_w16_2.btbb.model.UserPrefs;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/general/ExitCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/general/ExitCommandTest.java
@@ -1,11 +1,11 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.general;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.general.ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT;
 
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.general.ExitCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
 

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/general/HelpCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/general/HelpCommandTest.java
@@ -1,11 +1,11 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.general;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.general.HelpCommand.SHOWING_HELP_MESSAGE;
 
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.general.HelpCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
 

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/BookingDescriptorTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/BookingDescriptorTest.java
@@ -1,0 +1,37 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.descriptors;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_BOOKING_AMY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_BOOKING_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.testutil.BookingDescriptorBuilder;
+
+class BookingDescriptorTest {
+    @Test
+    public void equals() {
+        // same values -> returns true
+        BookingDescriptor descriptorWithSameValues = new BookingDescriptor(DESC_BOOKING_AMY);
+        assertTrue(DESC_BOOKING_AMY.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(DESC_BOOKING_AMY.equals(DESC_BOOKING_AMY));
+
+        // null -> returns false
+        assertFalse(DESC_BOOKING_AMY.equals(null));
+
+        // different types -> returns false
+        assertFalse(DESC_BOOKING_AMY.equals(5));
+
+        // different values -> returns false
+        assertFalse(DESC_BOOKING_AMY.equals(DESC_BOOKING_BOB));
+
+        // different phone -> returns false
+        BookingDescriptor editedBooking = new BookingDescriptorBuilder(DESC_BOOKING_AMY)
+                .withPhone(VALID_PHONE_BOB).build();
+        assertFalse(DESC_BOOKING_AMY.equals(editedBooking));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/BookingDescriptorTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/BookingDescriptorTest.java
@@ -30,8 +30,8 @@ class BookingDescriptorTest {
         assertFalse(DESC_BOOKING_AMY.equals(DESC_BOOKING_BOB));
 
         // different phone -> returns false
-        BookingDescriptor editedBooking = new BookingDescriptorBuilder(DESC_BOOKING_AMY)
+        BookingDescriptor editedBookingDescriptor = new BookingDescriptorBuilder(DESC_BOOKING_AMY)
                 .withPhone(VALID_PHONE_BOB).build();
-        assertFalse(DESC_BOOKING_AMY.equals(editedBooking));
+        assertFalse(DESC_BOOKING_AMY.equals(editedBookingDescriptor));
     }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/ClientDescriptorTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/ClientDescriptorTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.descriptors;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_AMY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_BOB;
@@ -11,10 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.testutil.ClientDescriptorBuilder;
 
-public class EditClientDescriptorTest {
+public class ClientDescriptorTest {
     @Test
     public void equals() {
         // same values -> returns true

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/booking/AddBookingCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/booking/AddBookingCommandParserTest.java
@@ -1,0 +1,57 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.booking;
+
+import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_BOB;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.booking.AddBookingCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.BookingDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.BookingDescriptorBuilder;
+
+class AddBookingCommandParserTest {
+    private AddBookingCommandParser parser = new AddBookingCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        BookingDescriptor expectedBookingDescriptor = new BookingDescriptorBuilder(BOOKING_BOB).build();
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + PHONE_DESC_BOB,
+                new AddBookingCommand(expectedBookingDescriptor));
+
+        // multiple phones - last phone accepted
+        assertParseSuccess(parser, PHONE_DESC_AMY + PHONE_DESC_BOB,
+                new AddBookingCommand(expectedBookingDescriptor));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBookingCommand.MESSAGE_USAGE);
+
+        // missing phone prefix
+        assertParseFailure(parser, VALID_PHONE_BOB, expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_PHONE_BOB, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid phone
+        assertParseFailure(parser, INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + PHONE_DESC_BOB,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBookingCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/booking/AddBookingCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/booking/AddBookingCommandParserTest.java
@@ -9,7 +9,7 @@ import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PREAMBL
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_FOR_BOB;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +23,7 @@ class AddBookingCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        BookingDescriptor expectedBookingDescriptor = new BookingDescriptorBuilder(BOOKING_BOB).build();
+        BookingDescriptor expectedBookingDescriptor = new BookingDescriptorBuilder(BOOKING_FOR_BOB).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + PHONE_DESC_BOB,

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/AddClientCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/AddClientCommandParserTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.AddClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.client.AddClientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Address;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Email;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Name;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/DeleteClientCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/DeleteClientCommandParserTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -8,7 +8,6 @@ import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_FIRST_CL
 import org.junit.jupiter.api.Test;
 
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.DeleteClientCommand;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.client.DeleteClientCommandParser;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/EditClientCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/EditClientCommandParserTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.EditClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.client.EditClientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Address;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Email;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Name;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/FindClientCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/FindClientCommandParserTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.FindClientCommand;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.client.FindClientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.NameContainsKeywordsPredicate;
 
 public class FindClientCommandParserTest {

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/util/ArgumentTokenizerTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/util/ArgumentTokenizerTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -6,10 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ArgumentMultimap;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ArgumentTokenizer;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.Prefix;
 
 public class ArgumentTokenizerTest {
     private final Prefix unknownPrefix = new Prefix("--u");

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/util/ParserUtilTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/util/ParserUtilTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.util;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ParserUtil.MESSAGE_INVALID_INDEX;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import ay2122s1_cs2103t_w16_2.btbb.exception.ParseException;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ParserUtil;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Address;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Email;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Name;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/BookingTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/BookingTest.java
@@ -1,10 +1,7 @@
 package ay2122s1_cs2103t_w16_2.btbb.model.booking;
 
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_ALICE;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_BENSON;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_CARL;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_DANIEL;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.BOB;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.FIONA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,19 +11,6 @@ import org.junit.jupiter.api.Test;
 import ay2122s1_cs2103t_w16_2.btbb.testutil.BookingBuilder;
 
 class BookingTest {
-    @Test
-    public void isSameBooking() {
-        // same object -> returns true
-        assertTrue(BOOKING_ALICE.equals(BOOKING_ALICE));
-
-        // null -> returns false
-        assertFalse(BOOKING_BENSON.equals(null));
-
-        // different client -> returns false
-        Booking editedRandomBooking = new BookingBuilder().forClient(BOB).build();
-        assertFalse(BOOKING_CARL.equals(editedRandomBooking));
-    }
-
     @Test
     public void equals() {
         // same values -> returns true

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/BookingTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/BookingTest.java
@@ -1,7 +1,7 @@
 package ay2122s1_cs2103t_w16_2.btbb.model.booking;
 
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_ALICE;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_DANIEL;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_FOR_ALICE;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_FOR_DANIEL;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.FIONA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,23 +14,23 @@ class BookingTest {
     @Test
     public void equals() {
         // same values -> returns true
-        Booking randomBookingCopy = new BookingBuilder(BOOKING_DANIEL).build();
-        assertTrue(BOOKING_DANIEL.equals(randomBookingCopy));
+        Booking randomBookingCopy = new BookingBuilder(BOOKING_FOR_DANIEL).build();
+        assertTrue(BOOKING_FOR_DANIEL.equals(randomBookingCopy));
 
         // same object -> returns true
-        assertTrue(BOOKING_ALICE.equals(BOOKING_ALICE));
+        assertTrue(BOOKING_FOR_ALICE.equals(BOOKING_FOR_ALICE));
 
         // null -> returns false
-        assertFalse(BOOKING_ALICE.equals(null));
+        assertFalse(BOOKING_FOR_ALICE.equals(null));
 
         // different type -> returns false
-        assertFalse(BOOKING_ALICE.equals(5));
+        assertFalse(BOOKING_FOR_ALICE.equals(5));
 
         // different booking -> returns false
-        assertFalse(BOOKING_ALICE.equals(BOOKING_DANIEL));
+        assertFalse(BOOKING_FOR_ALICE.equals(BOOKING_FOR_DANIEL));
 
         // different client -> returns false
-        Booking editedRandomBooking = new BookingBuilder(BOOKING_ALICE).forClient(FIONA).build();
-        assertFalse(BOOKING_ALICE.equals(editedRandomBooking));
+        Booking editedRandomBooking = new BookingBuilder(BOOKING_FOR_ALICE).forClient(FIONA).build();
+        assertFalse(BOOKING_FOR_ALICE.equals(editedRandomBooking));
     }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/BookingTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/BookingTest.java
@@ -1,10 +1,11 @@
 package ay2122s1_cs2103t_w16_2.btbb.model.booking;
 
-import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_1;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_2;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_3;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_4;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_ALICE;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_BENSON;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_CARL;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_DANIEL;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.FIONA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -16,36 +17,36 @@ class BookingTest {
     @Test
     public void isSameBooking() {
         // same object -> returns true
-        assertTrue(RANDOM_BOOKING_1.equals(RANDOM_BOOKING_1));
+        assertTrue(BOOKING_ALICE.equals(BOOKING_ALICE));
 
         // null -> returns false
-        assertFalse(RANDOM_BOOKING_2.equals(null));
+        assertFalse(BOOKING_BENSON.equals(null));
 
-        // different phone -> returns false
-        Booking editedRandomBooking = new BookingBuilder(RANDOM_BOOKING_3).withPhone(VALID_PHONE_BOB).build();
-        assertFalse(RANDOM_BOOKING_3.equals(editedRandomBooking));
+        // different client -> returns false
+        Booking editedRandomBooking = new BookingBuilder().forClient(BOB).build();
+        assertFalse(BOOKING_CARL.equals(editedRandomBooking));
     }
 
     @Test
     public void equals() {
         // same values -> returns true
-        Booking randomBookingCopy = new BookingBuilder(RANDOM_BOOKING_4).build();
-        assertTrue(RANDOM_BOOKING_4.equals(randomBookingCopy));
+        Booking randomBookingCopy = new BookingBuilder(BOOKING_DANIEL).build();
+        assertTrue(BOOKING_DANIEL.equals(randomBookingCopy));
 
         // same object -> returns true
-        assertTrue(RANDOM_BOOKING_1.equals(RANDOM_BOOKING_1));
+        assertTrue(BOOKING_ALICE.equals(BOOKING_ALICE));
 
         // null -> returns false
-        assertFalse(RANDOM_BOOKING_1.equals(null));
+        assertFalse(BOOKING_ALICE.equals(null));
 
         // different type -> returns false
-        assertFalse(RANDOM_BOOKING_1.equals(5));
+        assertFalse(BOOKING_ALICE.equals(5));
 
         // different booking -> returns false
-        assertFalse(RANDOM_BOOKING_1.equals(RANDOM_BOOKING_4));
+        assertFalse(BOOKING_ALICE.equals(BOOKING_DANIEL));
 
-        // different phone -> returns false
-        Booking editedRandomBooking = new BookingBuilder(RANDOM_BOOKING_1).withPhone(VALID_PHONE_BOB).build();
-        assertFalse(RANDOM_BOOKING_1.equals(editedRandomBooking));
+        // different client -> returns false
+        Booking editedRandomBooking = new BookingBuilder(BOOKING_ALICE).forClient(FIONA).build();
+        assertFalse(BOOKING_ALICE.equals(editedRandomBooking));
     }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/BookingTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/BookingTest.java
@@ -14,8 +14,8 @@ class BookingTest {
     @Test
     public void equals() {
         // same values -> returns true
-        Booking randomBookingCopy = new BookingBuilder(BOOKING_FOR_DANIEL).build();
-        assertTrue(BOOKING_FOR_DANIEL.equals(randomBookingCopy));
+        Booking bookingCopy = new BookingBuilder(BOOKING_FOR_DANIEL).build();
+        assertTrue(BOOKING_FOR_DANIEL.equals(bookingCopy));
 
         // same object -> returns true
         assertTrue(BOOKING_FOR_ALICE.equals(BOOKING_FOR_ALICE));

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/BookingTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/BookingTest.java
@@ -1,0 +1,51 @@
+package ay2122s1_cs2103t_w16_2.btbb.model.booking;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_1;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_2;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_3;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_4;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.testutil.BookingBuilder;
+
+class BookingTest {
+    @Test
+    public void isSameBooking() {
+        // same object -> returns true
+        assertTrue(RANDOM_BOOKING_1.equals(RANDOM_BOOKING_1));
+
+        // null -> returns false
+        assertFalse(RANDOM_BOOKING_2.equals(null));
+
+        // different phone -> returns false
+        Booking editedRandomBooking = new BookingBuilder(RANDOM_BOOKING_3).withPhone(VALID_PHONE_BOB).build();
+        assertFalse(RANDOM_BOOKING_3.equals(editedRandomBooking));
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        Booking randomBookingCopy = new BookingBuilder(RANDOM_BOOKING_4).build();
+        assertTrue(RANDOM_BOOKING_4.equals(randomBookingCopy));
+
+        // same object -> returns true
+        assertTrue(RANDOM_BOOKING_1.equals(RANDOM_BOOKING_1));
+
+        // null -> returns false
+        assertFalse(RANDOM_BOOKING_1.equals(null));
+
+        // different type -> returns false
+        assertFalse(RANDOM_BOOKING_1.equals(5));
+
+        // different booking -> returns false
+        assertFalse(RANDOM_BOOKING_1.equals(RANDOM_BOOKING_4));
+
+        // different phone -> returns false
+        Booking editedRandomBooking = new BookingBuilder(RANDOM_BOOKING_1).withPhone(VALID_PHONE_BOB).build();
+        assertFalse(RANDOM_BOOKING_1.equals(editedRandomBooking));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingListTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingListTest.java
@@ -1,8 +1,8 @@
 package ay2122s1_cs2103t_w16_2.btbb.model.booking;
 
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_1;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_2;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_ALICE;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_BENSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,13 +21,13 @@ class UniqueBookingListTest {
 
     @Test
     public void contains_bookingNotInList_returnsFalse() {
-        assertFalse(uniqueBookingList.contains(RANDOM_BOOKING_1));
+        assertFalse(uniqueBookingList.contains(BOOKING_ALICE));
     }
 
     @Test
     public void contains_bookingInList_returnsTrue() {
-        uniqueBookingList.add(RANDOM_BOOKING_1);
-        assertTrue(uniqueBookingList.contains(RANDOM_BOOKING_1));
+        uniqueBookingList.add(BOOKING_ALICE);
+        assertTrue(uniqueBookingList.contains(BOOKING_ALICE));
     }
 
     @Test
@@ -37,34 +37,34 @@ class UniqueBookingListTest {
 
     @Test
     public void setBooking_nullTargetBooking_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueBookingList.setBooking(null, RANDOM_BOOKING_1));
+        assertThrows(NullPointerException.class, () -> uniqueBookingList.setBooking(null, BOOKING_ALICE));
     }
 
     @Test
     public void setBooking_nullEditedBooking_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueBookingList.setBooking(RANDOM_BOOKING_1, null));
+        assertThrows(NullPointerException.class, () -> uniqueBookingList.setBooking(BOOKING_ALICE, null));
     }
 
     @Test
     public void setBooking_targetBookingNotInList_throwsBookingNotFoundException() {
-        assertThrows(NotFoundException.class, () -> uniqueBookingList.setBooking(RANDOM_BOOKING_1, RANDOM_BOOKING_1));
+        assertThrows(NotFoundException.class, () -> uniqueBookingList.setBooking(BOOKING_ALICE, BOOKING_ALICE));
     }
 
     @Test
     public void setBooking_editedBookingIsSameBooking_success() throws NotFoundException {
-        uniqueBookingList.add(RANDOM_BOOKING_1);
-        uniqueBookingList.setBooking(RANDOM_BOOKING_1, RANDOM_BOOKING_1);
+        uniqueBookingList.add(BOOKING_ALICE);
+        uniqueBookingList.setBooking(BOOKING_ALICE, BOOKING_ALICE);
         UniqueBookingList expectedUniqueBookingList = new UniqueBookingList();
-        expectedUniqueBookingList.add(RANDOM_BOOKING_1);
+        expectedUniqueBookingList.add(BOOKING_ALICE);
         assertEquals(expectedUniqueBookingList, uniqueBookingList);
     }
 
     @Test
     public void setBooking_editedBookingHasDifferentIdentity_success() throws NotFoundException {
-        uniqueBookingList.add(RANDOM_BOOKING_1);
-        uniqueBookingList.setBooking(RANDOM_BOOKING_1, RANDOM_BOOKING_2);
+        uniqueBookingList.add(BOOKING_ALICE);
+        uniqueBookingList.setBooking(BOOKING_ALICE, BOOKING_BENSON);
         UniqueBookingList expectedUniqueBookingList = new UniqueBookingList();
-        expectedUniqueBookingList.add(RANDOM_BOOKING_2);
+        expectedUniqueBookingList.add(BOOKING_BENSON);
         assertEquals(expectedUniqueBookingList, uniqueBookingList);
     }
 

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingListTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingListTest.java
@@ -72,4 +72,23 @@ class UniqueBookingListTest {
     public void remove_nullBooking_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniqueBookingList.remove(null));
     }
+
+    @Test
+    public void remove_bookingDoesNotExist_throwsBookingNotFoundException() {
+        assertThrows(NotFoundException.class, () -> uniqueBookingList.remove(BOOKING_ALICE));
+    }
+
+    @Test
+    public void remove_existingBooking_removesBooking() throws NotFoundException {
+        uniqueBookingList.add(BOOKING_ALICE);
+        uniqueBookingList.remove(BOOKING_ALICE);
+        UniqueBookingList expectedUniqueBookingList = new UniqueBookingList();
+        assertEquals(expectedUniqueBookingList, uniqueBookingList);
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+            -> uniqueBookingList.asUnmodifiableObservableList().remove(0));
+    }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingListTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingListTest.java
@@ -1,0 +1,75 @@
+package ay2122s1_cs2103t_w16_2.btbb.model.booking;
+
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_1;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.RANDOM_BOOKING_2;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
+
+class UniqueBookingListTest {
+    private final UniqueBookingList uniqueBookingList = new UniqueBookingList();
+
+    @Test
+    public void contains_nullBooking_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBookingList.contains(null));
+    }
+
+    @Test
+    public void contains_bookingNotInList_returnsFalse() {
+        assertFalse(uniqueBookingList.contains(RANDOM_BOOKING_1));
+    }
+
+    @Test
+    public void contains_bookingInList_returnsTrue() {
+        uniqueBookingList.add(RANDOM_BOOKING_1);
+        assertTrue(uniqueBookingList.contains(RANDOM_BOOKING_1));
+    }
+
+    @Test
+    public void add_nullBooking_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBookingList.add(null));
+    }
+
+    @Test
+    public void setBooking_nullTargetBooking_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBookingList.setBooking(null, RANDOM_BOOKING_1));
+    }
+
+    @Test
+    public void setBooking_nullEditedBooking_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBookingList.setBooking(RANDOM_BOOKING_1, null));
+    }
+
+    @Test
+    public void setBooking_targetBookingNotInList_throwsBookingNotFoundException() {
+        assertThrows(NotFoundException.class, () -> uniqueBookingList.setBooking(RANDOM_BOOKING_1, RANDOM_BOOKING_1));
+    }
+
+    @Test
+    public void setBooking_editedBookingIsSameBooking_success() throws NotFoundException {
+        uniqueBookingList.add(RANDOM_BOOKING_1);
+        uniqueBookingList.setBooking(RANDOM_BOOKING_1, RANDOM_BOOKING_1);
+        UniqueBookingList expectedUniqueBookingList = new UniqueBookingList();
+        expectedUniqueBookingList.add(RANDOM_BOOKING_1);
+        assertEquals(expectedUniqueBookingList, uniqueBookingList);
+    }
+
+    @Test
+    public void setBooking_editedBookingHasDifferentIdentity_success() throws NotFoundException {
+        uniqueBookingList.add(RANDOM_BOOKING_1);
+        uniqueBookingList.setBooking(RANDOM_BOOKING_1, RANDOM_BOOKING_2);
+        UniqueBookingList expectedUniqueBookingList = new UniqueBookingList();
+        expectedUniqueBookingList.add(RANDOM_BOOKING_2);
+        assertEquals(expectedUniqueBookingList, uniqueBookingList);
+    }
+
+    @Test
+    public void remove_nullBooking_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBookingList.remove(null));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingListTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/booking/UniqueBookingListTest.java
@@ -1,8 +1,8 @@
 package ay2122s1_cs2103t_w16_2.btbb.model.booking;
 
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_ALICE;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_BENSON;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_FOR_ALICE;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_FOR_BENSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,13 +21,13 @@ class UniqueBookingListTest {
 
     @Test
     public void contains_bookingNotInList_returnsFalse() {
-        assertFalse(uniqueBookingList.contains(BOOKING_ALICE));
+        assertFalse(uniqueBookingList.contains(BOOKING_FOR_ALICE));
     }
 
     @Test
     public void contains_bookingInList_returnsTrue() {
-        uniqueBookingList.add(BOOKING_ALICE);
-        assertTrue(uniqueBookingList.contains(BOOKING_ALICE));
+        uniqueBookingList.add(BOOKING_FOR_ALICE);
+        assertTrue(uniqueBookingList.contains(BOOKING_FOR_ALICE));
     }
 
     @Test
@@ -37,34 +37,34 @@ class UniqueBookingListTest {
 
     @Test
     public void setBooking_nullTargetBooking_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueBookingList.setBooking(null, BOOKING_ALICE));
+        assertThrows(NullPointerException.class, () -> uniqueBookingList.setBooking(null, BOOKING_FOR_ALICE));
     }
 
     @Test
     public void setBooking_nullEditedBooking_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniqueBookingList.setBooking(BOOKING_ALICE, null));
+        assertThrows(NullPointerException.class, () -> uniqueBookingList.setBooking(BOOKING_FOR_ALICE, null));
     }
 
     @Test
     public void setBooking_targetBookingNotInList_throwsBookingNotFoundException() {
-        assertThrows(NotFoundException.class, () -> uniqueBookingList.setBooking(BOOKING_ALICE, BOOKING_ALICE));
+        assertThrows(NotFoundException.class, () -> uniqueBookingList.setBooking(BOOKING_FOR_ALICE, BOOKING_FOR_ALICE));
     }
 
     @Test
     public void setBooking_editedBookingIsSameBooking_success() throws NotFoundException {
-        uniqueBookingList.add(BOOKING_ALICE);
-        uniqueBookingList.setBooking(BOOKING_ALICE, BOOKING_ALICE);
+        uniqueBookingList.add(BOOKING_FOR_ALICE);
+        uniqueBookingList.setBooking(BOOKING_FOR_ALICE, BOOKING_FOR_ALICE);
         UniqueBookingList expectedUniqueBookingList = new UniqueBookingList();
-        expectedUniqueBookingList.add(BOOKING_ALICE);
+        expectedUniqueBookingList.add(BOOKING_FOR_ALICE);
         assertEquals(expectedUniqueBookingList, uniqueBookingList);
     }
 
     @Test
     public void setBooking_editedBookingHasDifferentIdentity_success() throws NotFoundException {
-        uniqueBookingList.add(BOOKING_ALICE);
-        uniqueBookingList.setBooking(BOOKING_ALICE, BOOKING_BENSON);
+        uniqueBookingList.add(BOOKING_FOR_ALICE);
+        uniqueBookingList.setBooking(BOOKING_FOR_ALICE, BOOKING_FOR_BENSON);
         UniqueBookingList expectedUniqueBookingList = new UniqueBookingList();
-        expectedUniqueBookingList.add(BOOKING_BENSON);
+        expectedUniqueBookingList.add(BOOKING_FOR_BENSON);
         assertEquals(expectedUniqueBookingList, uniqueBookingList);
     }
 
@@ -75,13 +75,13 @@ class UniqueBookingListTest {
 
     @Test
     public void remove_bookingDoesNotExist_throwsBookingNotFoundException() {
-        assertThrows(NotFoundException.class, () -> uniqueBookingList.remove(BOOKING_ALICE));
+        assertThrows(NotFoundException.class, () -> uniqueBookingList.remove(BOOKING_FOR_ALICE));
     }
 
     @Test
     public void remove_existingBooking_removesBooking() throws NotFoundException {
-        uniqueBookingList.add(BOOKING_ALICE);
-        uniqueBookingList.remove(BOOKING_ALICE);
+        uniqueBookingList.add(BOOKING_FOR_ALICE);
+        uniqueBookingList.remove(BOOKING_FOR_ALICE);
         UniqueBookingList expectedUniqueBookingList = new UniqueBookingList();
         assertEquals(expectedUniqueBookingList, uniqueBookingList);
     }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/storage/JsonAdaptedBookingTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/storage/JsonAdaptedBookingTest.java
@@ -1,7 +1,7 @@
 package ay2122s1_cs2103t_w16_2.btbb.storage;
 
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_FIONA;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_FOR_FIONA;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.FIONA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -23,13 +23,13 @@ class JsonAdaptedBookingTest {
     public void setUp() {
         addressBook = new AddressBook();
         addressBook.addClient(FIONA);
-        addressBook.addBooking(BOOKING_FIONA);
+        addressBook.addBooking(BOOKING_FOR_FIONA);
     }
 
     @Test
     public void toModelType_validBookingDetails_returnsBooking() throws Exception {
-        JsonAdaptedBooking booking = new JsonAdaptedBooking(BOOKING_FIONA);
-        assertEquals(BOOKING_FIONA, booking.toModelType(addressBook));
+        JsonAdaptedBooking booking = new JsonAdaptedBooking(BOOKING_FOR_FIONA);
+        assertEquals(BOOKING_FOR_FIONA, booking.toModelType(addressBook));
     }
 
     @Test

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/storage/JsonAdaptedBookingTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/storage/JsonAdaptedBookingTest.java
@@ -23,7 +23,6 @@ class JsonAdaptedBookingTest {
     public void setUp() {
         addressBook = new AddressBook();
         addressBook.addClient(FIONA);
-        addressBook.addBooking(BOOKING_FOR_FIONA);
     }
 
     @Test

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/storage/JsonAdaptedBookingTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/storage/JsonAdaptedBookingTest.java
@@ -1,0 +1,41 @@
+package ay2122s1_cs2103t_w16_2.btbb.storage;
+
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalBookings.BOOKING_FIONA;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.FIONA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.exception.IllegalValueException;
+import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+
+class JsonAdaptedBookingTest {
+    private static final String INVALID_PHONE = "+651234";
+
+    private static final String VALID_PHONE = FIONA.getPhone().toString();
+
+    private AddressBook addressBook;
+
+    @BeforeEach
+    public void setUp() {
+        addressBook = new AddressBook();
+        addressBook.addClient(FIONA);
+        addressBook.addBooking(BOOKING_FIONA);
+    }
+
+    @Test
+    public void toModelType_validBookingDetails_returnsBooking() throws Exception {
+        JsonAdaptedBooking booking = new JsonAdaptedBooking(BOOKING_FIONA);
+        assertEquals(BOOKING_FIONA, booking.toModelType(addressBook));
+    }
+
+    @Test
+    public void toModelType_invalidPhone_throwsIllegalValueException() {
+        JsonAdaptedBooking booking = new JsonAdaptedBooking(INVALID_PHONE);
+        String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, () -> booking.toModelType(addressBook));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/BookingBuilder.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/BookingBuilder.java
@@ -1,37 +1,40 @@
 package ay2122s1_cs2103t_w16_2.btbb.testutil;
 
 import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
-import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
 
 /**
  * A utility class to help with building Booking objects.
  */
 public class BookingBuilder {
-    private Phone phone;
+    private Client client;
 
     /**
      * Creates a {@code BookingBuilder} with the default details.
      */
     public BookingBuilder() {
-        phone = new ClientBuilder().build().getPhone();
+        client = new ClientBuilder().build();
     }
 
     /**
      * Initializes the BookingBuilder with the data of {@code bookingToCopy}.
      */
     public BookingBuilder(Booking bookingToCopy) {
-        phone = bookingToCopy.getPhone();
+        client = bookingToCopy.getClient();
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Booking} that we are building.
+     * Sets the {@code client} of the {@code BookingBuilder} that we are building.
+     *
+     * @param client The client associated with the booking we are building.
+     * @return The {@code BookingBuilder} object.
      */
-    public BookingBuilder withPhone(String phone) {
-        this.phone = new Phone(phone);
+    public BookingBuilder forClient(Client client) {
+        this.client = client;
         return this;
     }
 
     public Booking build() {
-        return new Booking(new ClientBuilder().withPhone(phone.toString()).build());
+        return new Booking(client);
     }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/BookingBuilder.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/BookingBuilder.java
@@ -18,6 +18,8 @@ public class BookingBuilder {
 
     /**
      * Initializes the BookingBuilder with the data of {@code bookingToCopy}.
+     *
+     * @param bookingToCopy The data from which to copy from to create a new booking.
      */
     public BookingBuilder(Booking bookingToCopy) {
         client = bookingToCopy.getClient();

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/BookingBuilder.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/BookingBuilder.java
@@ -1,0 +1,37 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+
+/**
+ * A utility class to help with building Booking objects.
+ */
+public class BookingBuilder {
+    private Phone phone;
+
+    /**
+     * Creates a {@code BookingBuilder} with the default details.
+     */
+    public BookingBuilder() {
+        phone = new ClientBuilder().build().getPhone();
+    }
+
+    /**
+     * Initializes the BookingBuilder with the data of {@code bookingToCopy}.
+     */
+    public BookingBuilder(Booking bookingToCopy) {
+        phone = bookingToCopy.getPhone();
+    }
+
+    /**
+     * Sets the {@code Phone} of the {@code Booking} that we are building.
+     */
+    public BookingBuilder withPhone(String phone) {
+        this.phone = new Phone(phone);
+        return this;
+    }
+
+    public Booking build() {
+        return new Booking(new ClientBuilder().withPhone(phone.toString()).build());
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/BookingDescriptorBuilder.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/BookingDescriptorBuilder.java
@@ -10,16 +10,26 @@ import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
 public class BookingDescriptorBuilder {
     private BookingDescriptor descriptor;
 
+    /**
+     * Creates an empty {@code BookingDescriptorBuilder}.
+     */
     public BookingDescriptorBuilder() {
         descriptor = new BookingDescriptor();
     }
 
+    /**
+     * Initializes the BookingDescriptorBuilder with the data of {@code descriptor}.
+     *
+     * @param descriptor The data from which to copy from to create a new booking descriptor.
+     */
     public BookingDescriptorBuilder(BookingDescriptor descriptor) {
         this.descriptor = new BookingDescriptor(descriptor);
     }
 
     /**
      * Returns a {@code BookingDescriptor} with fields containing {@code booking}'s details
+     *
+     * @param booking The booking from which to copy from to create a new booking descriptor.
      */
     public BookingDescriptorBuilder(Booking booking) {
         descriptor = new BookingDescriptor();
@@ -28,6 +38,9 @@ public class BookingDescriptorBuilder {
 
     /**
      * Sets the {@code Phone} of the {@code BookingDescriptor} that we are building.
+     *
+     * @param phone The phone that should be set.
+     * @return A BookingDescriptorBuilder object that contains the new phone details.
      */
     public BookingDescriptorBuilder withPhone(String phone) {
         descriptor.setPhone(new Phone(phone));

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/BookingDescriptorBuilder.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/BookingDescriptorBuilder.java
@@ -1,0 +1,40 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil;
+
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.BookingDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+
+/**
+ * A utility class to help with building BookingDescriptorBuilder objects.
+ */
+public class BookingDescriptorBuilder {
+    private BookingDescriptor descriptor;
+
+    public BookingDescriptorBuilder() {
+        descriptor = new BookingDescriptor();
+    }
+
+    public BookingDescriptorBuilder(BookingDescriptor descriptor) {
+        this.descriptor = new BookingDescriptor(descriptor);
+    }
+
+    /**
+     * Returns a {@code BookingDescriptor} with fields containing {@code booking}'s details
+     */
+    public BookingDescriptorBuilder(Booking booking) {
+        descriptor = new BookingDescriptor();
+        descriptor.setPhone(booking.getPhone());
+    }
+
+    /**
+     * Sets the {@code Phone} of the {@code BookingDescriptor} that we are building.
+     */
+    public BookingDescriptorBuilder withPhone(String phone) {
+        descriptor.setPhone(new Phone(phone));
+        return this;
+    }
+
+    public BookingDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/TypicalBookings.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/TypicalBookings.java
@@ -5,7 +5,17 @@ import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_P
 
 import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
 
+/**
+ * A utility class containing a list of {@code Booking} objects to be used in tests.
+ */
 public class TypicalBookings {
+    public static final Booking RANDOM_BOOKING_1 = new BookingBuilder().withPhone("98562145").build();
+    public static final Booking RANDOM_BOOKING_2 = new BookingBuilder().withPhone("45625411").build();
+    public static final Booking RANDOM_BOOKING_3 = new BookingBuilder().withPhone("57854632").build();
+    public static final Booking RANDOM_BOOKING_4 = new BookingBuilder().withPhone("12345678").build();
+    public static final Booking RANDOM_BOOKING_5 = new BookingBuilder().withPhone("10214268").build();
+    public static final Booking RANDOM_BOOKING_6 = new BookingBuilder().withPhone("99999999").build();
+
     // Manually added - Booking's details found in {@code CommandTestUtil}
     public static final Booking BOOKING_AMY = new BookingBuilder().withPhone(VALID_PHONE_AMY).build();
     public static final Booking BOOKING_BOB = new BookingBuilder().withPhone(VALID_PHONE_BOB).build();

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/TypicalBookings.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/TypicalBookings.java
@@ -1,7 +1,14 @@
 package ay2122s1_cs2103t_w16_2.btbb.testutil;
 
-import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
-import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.ALICE;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.AMY;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.BENSON;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.CARL;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.DANIEL;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.ELLE;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.FIONA;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.GEORGE;
 
 import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
 
@@ -9,14 +16,15 @@ import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
  * A utility class containing a list of {@code Booking} objects to be used in tests.
  */
 public class TypicalBookings {
-    public static final Booking RANDOM_BOOKING_1 = new BookingBuilder().withPhone("98562145").build();
-    public static final Booking RANDOM_BOOKING_2 = new BookingBuilder().withPhone("45625411").build();
-    public static final Booking RANDOM_BOOKING_3 = new BookingBuilder().withPhone("57854632").build();
-    public static final Booking RANDOM_BOOKING_4 = new BookingBuilder().withPhone("12345678").build();
-    public static final Booking RANDOM_BOOKING_5 = new BookingBuilder().withPhone("10214268").build();
-    public static final Booking RANDOM_BOOKING_6 = new BookingBuilder().withPhone("99999999").build();
+    public static final Booking BOOKING_ALICE = new BookingBuilder().forClient(ALICE).build();
+    public static final Booking BOOKING_BENSON = new BookingBuilder().forClient(BENSON).build();
+    public static final Booking BOOKING_CARL = new BookingBuilder().forClient(CARL).build();
+    public static final Booking BOOKING_DANIEL = new BookingBuilder().forClient(DANIEL).build();
+    public static final Booking BOOKING_ELLE = new BookingBuilder().forClient(ELLE).build();
+    public static final Booking BOOKING_FIONA = new BookingBuilder().forClient(FIONA).build();
+    public static final Booking BOOKING_GEORGE = new BookingBuilder().forClient(GEORGE).build();
 
     // Manually added - Booking's details found in {@code CommandTestUtil}
-    public static final Booking BOOKING_AMY = new BookingBuilder().withPhone(VALID_PHONE_AMY).build();
-    public static final Booking BOOKING_BOB = new BookingBuilder().withPhone(VALID_PHONE_BOB).build();
+    public static final Booking BOOKING_AMY = new BookingBuilder().forClient(AMY).build();
+    public static final Booking BOOKING_BOB = new BookingBuilder().forClient(BOB).build();
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/TypicalBookings.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/TypicalBookings.java
@@ -16,15 +16,15 @@ import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
  * A utility class containing a list of {@code Booking} objects to be used in tests.
  */
 public class TypicalBookings {
-    public static final Booking BOOKING_ALICE = new BookingBuilder().forClient(ALICE).build();
-    public static final Booking BOOKING_BENSON = new BookingBuilder().forClient(BENSON).build();
-    public static final Booking BOOKING_CARL = new BookingBuilder().forClient(CARL).build();
-    public static final Booking BOOKING_DANIEL = new BookingBuilder().forClient(DANIEL).build();
-    public static final Booking BOOKING_ELLE = new BookingBuilder().forClient(ELLE).build();
-    public static final Booking BOOKING_FIONA = new BookingBuilder().forClient(FIONA).build();
-    public static final Booking BOOKING_GEORGE = new BookingBuilder().forClient(GEORGE).build();
+    public static final Booking BOOKING_FOR_ALICE = new BookingBuilder().forClient(ALICE).build();
+    public static final Booking BOOKING_FOR_BENSON = new BookingBuilder().forClient(BENSON).build();
+    public static final Booking BOOKING_FOR_CARL = new BookingBuilder().forClient(CARL).build();
+    public static final Booking BOOKING_FOR_DANIEL = new BookingBuilder().forClient(DANIEL).build();
+    public static final Booking BOOKING_FOR_ELLE = new BookingBuilder().forClient(ELLE).build();
+    public static final Booking BOOKING_FOR_FIONA = new BookingBuilder().forClient(FIONA).build();
+    public static final Booking BOOKING_FOR_GEORGE = new BookingBuilder().forClient(GEORGE).build();
 
     // Manually added - Booking's details found in {@code CommandTestUtil}
-    public static final Booking BOOKING_AMY = new BookingBuilder().forClient(AMY).build();
-    public static final Booking BOOKING_BOB = new BookingBuilder().forClient(BOB).build();
+    public static final Booking BOOKING_FOR_AMY = new BookingBuilder().forClient(AMY).build();
+    public static final Booking BOOKING_FOR_BOB = new BookingBuilder().forClient(BOB).build();
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/TypicalBookings.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/TypicalBookings.java
@@ -1,0 +1,12 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
+
+public class TypicalBookings {
+    // Manually added - Booking's details found in {@code CommandTestUtil}
+    public static final Booking BOOKING_AMY = new BookingBuilder().withPhone(VALID_PHONE_AMY).build();
+    public static final Booking BOOKING_BOB = new BookingBuilder().withPhone(VALID_PHONE_BOB).build();
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStub.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStub.java
@@ -1,0 +1,104 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil.stubs;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.GuiSettings;
+import ay2122s1_cs2103t_w16_2.btbb.model.Model;
+import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyAddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyUserPrefs;
+import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+import javafx.collections.ObservableList;
+
+/**
+ * A default model stub that has all of its methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBookFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBook(ReadOnlyAddressBook newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addBooking(Booking booking) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredBookingList(Predicate<Booking> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addClient(Client client) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasClient(Client client) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Optional<Client> getClientByPhone(Phone phone) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteClient(Client target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setClient(Client target, Client editedClient) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Client> getFilteredClientList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredClientList(Predicate<Client> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubAcceptingBookingAdded.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubAcceptingBookingAdded.java
@@ -1,0 +1,47 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil.stubs;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyAddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.booking.Booking;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+
+/**
+ * A Model stub that always accepts the booking being added if it already contains the client that the booking
+ * is associated with.
+ */
+public class ModelStubAcceptingBookingAdded extends ModelStub {
+    private final ArrayList<Client> clientsAdded = new ArrayList<>();
+    private final ArrayList<Booking> bookingsAdded = new ArrayList<>();
+
+    public ArrayList<Booking> getBookingsAdded() {
+        return bookingsAdded;
+    }
+
+    @Override
+    public void addClient(Client client) {
+        requireNonNull(client);
+        clientsAdded.add(client);
+    }
+
+    @Override
+    public void addBooking(Booking booking) {
+        requireNonNull(booking);
+        bookingsAdded.add(booking);
+    }
+
+    @Override
+    public Optional<Client> getClientByPhone(Phone phone) {
+        return clientsAdded.stream().filter(client -> client.getPhone().equals(phone)).findFirst();
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        return new AddressBook();
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubAcceptingClientAdded.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubAcceptingClientAdded.java
@@ -12,7 +12,11 @@ import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
  * A Model stub that always accepts the client being added.
  */
 public class ModelStubAcceptingClientAdded extends ModelStub {
-    public final ArrayList<Client> clientsAdded = new ArrayList<>();
+    private final ArrayList<Client> clientsAdded = new ArrayList<>();
+
+    public ArrayList<Client> getClientsAdded() {
+        return clientsAdded;
+    }
 
     @Override
     public boolean hasClient(Client client) {

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubAcceptingClientAdded.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubAcceptingClientAdded.java
@@ -1,0 +1,33 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil.stubs;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyAddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
+
+/**
+ * A Model stub that always accepts the client being added.
+ */
+public class ModelStubAcceptingClientAdded extends ModelStub {
+    public final ArrayList<Client> clientsAdded = new ArrayList<>();
+
+    @Override
+    public boolean hasClient(Client client) {
+        requireNonNull(client);
+        return clientsAdded.stream().anyMatch(client::isSameClient);
+    }
+
+    @Override
+    public void addClient(Client client) {
+        requireNonNull(client);
+        clientsAdded.add(client);
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        return new AddressBook();
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubWithClient.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubWithClient.java
@@ -1,0 +1,28 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil.stubs;
+
+import static java.util.Objects.requireNonNull;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
+
+/**
+ * A Model stub that contains a single client.
+ */
+public class ModelStubWithClient extends ModelStub {
+    private final Client client;
+
+    /**
+     * Constructs a ModelStubWithClient object which contains the given client.
+     *
+     * @param client The client that this model should contain.
+     */
+    public ModelStubWithClient(Client client) {
+        requireNonNull(client);
+        this.client = client;
+    }
+
+    @Override
+    public boolean hasClient(Client client) {
+        requireNonNull(client);
+        return this.client.isSameClient(client);
+    }
+}


### PR DESCRIPTION
# Changes
- Reorganised test packages so that it mirrors the main package.
- Added new tests for all exception classes in the project.
- Added all booking related test (e.g. `AddBookingCommandTest`, `BookingTest`, etc)
   - Note that more tests will be added to these files as more features gets implemented.
- Implemented several methods in the main package to support the newly added tests.
- Added `BookingBuilder`, `BookingDescriptorBuilder`, `TypicalBookings` which can be used for future booking related test cases.

Closes https://github.com/AY2122S1-CS2103T-W16-2/tp/issues/47.