### PR TITLE
Implement test skeleton for order

### DIFF
--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/exception/NotFoundException.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/exception/NotFoundException.java
@@ -1,7 +1,9 @@
 package ay2122s1_cs2103t_w16_2.btbb.exception;
 
 public class NotFoundException extends Exception {
+    public static final String NOT_FOUND_EXCEPTION_MESSAGE_FORMAT = "The specified %s cannot be found.";
+
     public NotFoundException(String notFoundItem) {
-        super("The specified " + notFoundItem + " cannot be found.");
+        super(String.format(NOT_FOUND_EXCEPTION_MESSAGE_FORMAT, notFoundItem));
     }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/CommandExceptionTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/CommandExceptionTest.java
@@ -1,0 +1,20 @@
+package ay2122s1_cs2103t_w16_2.btbb.exception;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class CommandExceptionTest {
+    private static final String COMMAND_EXCEPTION_MESSAGE = "This is a CommandException.";
+
+    @Test
+    public void testCommandException() {
+        assertThrows(CommandException.class, () -> {
+            throw new CommandException(COMMAND_EXCEPTION_MESSAGE);
+        });
+
+        assertThrows(CommandException.class, () -> {
+            throw new CommandException(COMMAND_EXCEPTION_MESSAGE, new Throwable());
+        });
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/DataConversionExceptionTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/DataConversionExceptionTest.java
@@ -1,0 +1,14 @@
+package ay2122s1_cs2103t_w16_2.btbb.exception;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class DataConversionExceptionTest {
+    @Test
+    public void testDataConversionException() {
+        assertThrows(DataConversionException.class, () -> {
+            throw new DataConversionException(new Exception());
+        });
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/IllegalValueExceptionTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/IllegalValueExceptionTest.java
@@ -1,0 +1,20 @@
+package ay2122s1_cs2103t_w16_2.btbb.exception;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class IllegalValueExceptionTest {
+    private static final String ILLEGAL_VALUE_EXCEPTION_MESSAGE = "This is a IllegalValueException.";
+
+    @Test
+    public void testIllegalValueException() {
+        assertThrows(CommandException.class, () -> {
+            throw new CommandException(ILLEGAL_VALUE_EXCEPTION_MESSAGE);
+        });
+
+        assertThrows(CommandException.class, () -> {
+            throw new CommandException(ILLEGAL_VALUE_EXCEPTION_MESSAGE, new Throwable());
+        });
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/NotFoundExceptionTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/NotFoundExceptionTest.java
@@ -1,0 +1,28 @@
+
+package ay2122s1_cs2103t_w16_2.btbb.exception;
+
+import static ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException.NOT_FOUND_EXCEPTION_MESSAGE_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class NotFoundExceptionTest {
+    private static final String NOT_FOUND_EXCEPTION_INPUT = "random input";
+    private static final String EXPECTED_EXCEPTION_MESSAGE = String.format(
+            NOT_FOUND_EXCEPTION_MESSAGE_FORMAT, NOT_FOUND_EXCEPTION_INPUT
+    );
+
+    @Test
+    public void testNotFoundException() {
+        assertThrows(NotFoundException.class, () -> {
+            throw new NotFoundException(NOT_FOUND_EXCEPTION_INPUT);
+        });
+
+        try {
+            throw new NotFoundException(NOT_FOUND_EXCEPTION_INPUT);
+        } catch (NotFoundException e) {
+            assertEquals(e.getMessage(), EXPECTED_EXCEPTION_MESSAGE);
+        }
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/ParseExceptionTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/exception/ParseExceptionTest.java
@@ -1,0 +1,20 @@
+package ay2122s1_cs2103t_w16_2.btbb.exception;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ParseExceptionTest {
+    private static final String PARSE_EXCEPTION_MESSAGE = "This is a ParseException.";
+
+    @Test
+    public void testParseException() {
+        assertThrows(ParseException.class, () -> {
+            throw new ParseException(PARSE_EXCEPTION_MESSAGE);
+        });
+
+        assertThrows(ParseException.class, () -> {
+            throw new ParseException(PARSE_EXCEPTION_MESSAGE, new Throwable());
+        });
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/CommandTestUtil.java
@@ -15,11 +15,13 @@ import java.util.List;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
 import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.OrderDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.NameContainsKeywordsPredicate;
 import ay2122s1_cs2103t_w16_2.btbb.testutil.ClientDescriptorBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderDescriptorBuilder;
 
 /**
  * Contains helper methods for testing commands.
@@ -54,6 +56,9 @@ public class CommandTestUtil {
     public static final ClientDescriptor DESC_AMY;
     public static final ClientDescriptor DESC_BOB;
 
+    public static final OrderDescriptor DESC_ORDER_AMY;
+    public static final OrderDescriptor DESC_ORDER_BOB;
+
     static {
         DESC_AMY = new ClientDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
@@ -61,6 +66,8 @@ public class CommandTestUtil {
         DESC_BOB = new ClientDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .build();
+        DESC_ORDER_AMY = new OrderDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        DESC_ORDER_BOB = new OrderDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
     }
 
     /**

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandIntegrationTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandIntegrationTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -7,7 +7,6 @@ import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.getTypicalAddr
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.AddClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
 import static java.util.Objects.requireNonNull;
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.GuiSettings;
 import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.AddClientCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/AddClientCommandTest.java
@@ -1,31 +1,23 @@
 package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.commons.core.GuiSettings;
 import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
-import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
-import ay2122s1_cs2103t_w16_2.btbb.model.Model;
-import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyAddressBook;
-import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyUserPrefs;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
-import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
 import ay2122s1_cs2103t_w16_2.btbb.testutil.ClientBuilder;
 import ay2122s1_cs2103t_w16_2.btbb.testutil.ClientDescriptorBuilder;
-import javafx.collections.ObservableList;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.stubs.ModelStub;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.stubs.ModelStubAcceptingClientAdded;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.stubs.ModelStubWithClient;
 
 public class AddClientCommandTest {
     @Test
@@ -42,7 +34,7 @@ public class AddClientCommandTest {
         CommandResult commandResult = new AddClientCommand(validClientDescriptor).execute(modelStub);
 
         assertEquals(String.format(AddClientCommand.MESSAGE_SUCCESS, validClient), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validClient), modelStub.clientsAdded);
+        assertEquals(Arrays.asList(validClient), modelStub.getClientsAdded());
     }
 
     @Test
@@ -78,137 +70,5 @@ public class AddClientCommandTest {
 
         // different client -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredOrderList(Predicate<Order> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addClient(Client client) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasClient(Client client) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteClient(Client target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setClient(Client target, Client editedClient) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Client> getFilteredClientList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredClientList(Predicate<Client> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addOrder(Order order) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasOrder(Order order) {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
-    /**
-     * A Model stub that contains a single client.
-     */
-    private class ModelStubWithClient extends ModelStub {
-        private final Client client;
-
-        ModelStubWithClient(Client client) {
-            requireNonNull(client);
-            this.client = client;
-        }
-
-        @Override
-        public boolean hasClient(Client client) {
-            requireNonNull(client);
-            return this.client.isSameClient(client);
-        }
-    }
-
-    /**
-     * A Model stub that always accept the client being added.
-     */
-    private class ModelStubAcceptingClientAdded extends ModelStub {
-        final ArrayList<Client> clientsAdded = new ArrayList<>();
-
-        @Override
-        public boolean hasClient(Client client) {
-            requireNonNull(client);
-            return clientsAdded.stream().anyMatch(client::isSameClient);
-        }
-
-        @Override
-        public void addClient(Client client) {
-            requireNonNull(client);
-            clientsAdded.add(client);
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
-        }
     }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/DeleteClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/DeleteClientCommandTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
 import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.DeleteClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
 import ay2122s1_cs2103t_w16_2.btbb.model.UserPrefs;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/EditClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/EditClientCommandTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_AMY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_BOB;
@@ -18,8 +18,6 @@ import org.junit.jupiter.api.Test;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
 import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.EditClientCommand;
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.ListClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/FindClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/FindClientCommandTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_CLIENTS_LISTED_OVERVIEW;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -15,7 +15,6 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.FindClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
 import ay2122s1_cs2103t_w16_2.btbb.model.UserPrefs;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/ListClientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/client/ListClientCommandTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.showClientAtIndex;
@@ -8,7 +8,6 @@ import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_FIRST_CL
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.ListClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
 import ay2122s1_cs2103t_w16_2.btbb.model.UserPrefs;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/general/ExitCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/general/ExitCommandTest.java
@@ -1,11 +1,11 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.general;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.general.ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT;
 
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.general.ExitCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
 

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/general/HelpCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/general/HelpCommandTest.java
@@ -1,11 +1,11 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.general;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.general.HelpCommand.SHOWING_HELP_MESSAGE;
 
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.commands.general.HelpCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
 

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderCommandIntegrationTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderCommandIntegrationTest.java
@@ -1,0 +1,39 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.OrderDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.Model;
+import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
+import ay2122s1_cs2103t_w16_2.btbb.model.UserPrefs;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderDescriptorBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code AddOrderCommand}.
+ */
+public class AddOrderCommandIntegrationTest {
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_newOrder_success() {
+        Order validOrder = new OrderBuilder().build();
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.addOrder(validOrder);
+        OrderDescriptor validOrderDescriptor = new OrderDescriptorBuilder(validOrder).build();
+
+        assertCommandSuccess(new AddOrderCommand(validOrderDescriptor), model,
+                String.format(AddOrderCommand.MESSAGE_SUCCESS, validOrder), expectedModel);
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderCommandTest.java
@@ -1,0 +1,62 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.OrderDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderDescriptorBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.stubs.ModelStubAcceptingOrderAdded;
+
+public class AddOrderCommandTest {
+    @Test
+    public void constructor_nullOrder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddOrderCommand(null));
+    }
+
+    @Test
+    public void execute_orderAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingOrderAdded modelStub = new ModelStubAcceptingOrderAdded();
+        Order validOrder = new OrderBuilder().build();
+        OrderDescriptor validOrderDescriptor = new OrderDescriptorBuilder(validOrder).build();
+
+        CommandResult commandResult = new AddOrderCommand(validOrderDescriptor).execute(modelStub);
+
+        assertEquals(String.format(AddOrderCommand.MESSAGE_SUCCESS, validOrder), commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validOrder), modelStub.getOrdersAdded());
+    }
+
+    @Test
+    public void equals() {
+        OrderDescriptor orderDescriptorForAmy = new OrderDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        OrderDescriptor orderDescriptorForBob = new OrderDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
+        AddOrderCommand addOrderForAmyCommand = new AddOrderCommand(orderDescriptorForAmy);
+        AddOrderCommand addOrderForBobCommand = new AddOrderCommand(orderDescriptorForBob);
+
+        // same object -> returns true
+        assertTrue(addOrderForAmyCommand.equals(addOrderForAmyCommand));
+
+        // same values -> returns true
+        AddOrderCommand addOrderForAmyCommandCopy = new AddOrderCommand(orderDescriptorForAmy);
+        assertTrue(addOrderForAmyCommand.equals(addOrderForAmyCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addOrderForAmyCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addOrderForAmyCommand.equals(null));
+
+        // different order -> returns false
+        assertFalse(addOrderForAmyCommand.equals(addOrderForBobCommand));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/EditClientDescriptorTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/EditClientDescriptorTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.commands;
+package ay2122s1_cs2103t_w16_2.btbb.logic.descriptors;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_AMY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_BOB;
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.testutil.ClientDescriptorBuilder;
 
 public class EditClientDescriptorTest {

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/OrderDescriptorTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/OrderDescriptorTest.java
@@ -30,8 +30,8 @@ class OrderDescriptorTest {
         assertFalse(DESC_ORDER_AMY.equals(DESC_ORDER_BOB));
 
         // different phone -> returns false
-        OrderDescriptor editedOrder = new OrderDescriptorBuilder(DESC_ORDER_AMY)
+        OrderDescriptor editedOrderDescriptor = new OrderDescriptorBuilder(DESC_ORDER_AMY)
                 .withPhone(VALID_PHONE_BOB).build();
-        assertFalse(DESC_ORDER_AMY.equals(editedOrder));
+        assertFalse(DESC_ORDER_AMY.equals(editedOrderDescriptor));
     }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/OrderDescriptorTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/OrderDescriptorTest.java
@@ -1,0 +1,37 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.descriptors;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_ORDER_AMY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_ORDER_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderDescriptorBuilder;
+
+class OrderDescriptorTest {
+    @Test
+    public void equals() {
+        // same values -> returns true
+        OrderDescriptor descriptorWithSameValues = new OrderDescriptor(DESC_ORDER_AMY);
+        assertTrue(DESC_ORDER_AMY.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(DESC_ORDER_AMY.equals(DESC_ORDER_AMY));
+
+        // null -> returns false
+        assertFalse(DESC_ORDER_AMY.equals(null));
+
+        // different types -> returns false
+        assertFalse(DESC_ORDER_AMY.equals(5));
+
+        // different values -> returns false
+        assertFalse(DESC_ORDER_AMY.equals(DESC_ORDER_BOB));
+
+        // different phone -> returns false
+        OrderDescriptor editedOrder = new OrderDescriptorBuilder(DESC_ORDER_AMY)
+                .withPhone(VALID_PHONE_BOB).build();
+        assertFalse(DESC_ORDER_AMY.equals(editedOrder));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/AddClientCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/AddClientCommandParserTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.AddClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.client.AddClientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Address;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Email;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Name;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/DeleteClientCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/DeleteClientCommandParserTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -8,7 +8,6 @@ import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_FIRST_CL
 import org.junit.jupiter.api.Test;
 
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.DeleteClientCommand;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.client.DeleteClientCommandParser;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/EditClientCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/EditClientCommandParserTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.EditClientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.client.EditClientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Address;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Email;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Name;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/FindClientCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/client/FindClientCommandParserTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.client;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.FindClientCommand;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.client.FindClientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.NameContainsKeywordsPredicate;
 
 public class FindClientCommandParserTest {

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/AddOrderCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/AddOrderCommandParserTest.java
@@ -1,0 +1,57 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.ORDER_BY_BOB;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.OrderDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderDescriptorBuilder;
+
+class AddOrderCommandParserTest {
+    private AddOrderCommandParser parser = new AddOrderCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        OrderDescriptor expectedBookingDescriptor = new OrderDescriptorBuilder(ORDER_BY_BOB).build();
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + PHONE_DESC_BOB,
+                new AddOrderCommand(expectedBookingDescriptor));
+
+        // multiple phones - last phone accepted
+        assertParseSuccess(parser, PHONE_DESC_AMY + PHONE_DESC_BOB,
+                new AddOrderCommand(expectedBookingDescriptor));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE);
+
+        // missing phone prefix
+        assertParseFailure(parser, VALID_PHONE_BOB, expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_PHONE_BOB, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid phone
+        assertParseFailure(parser, INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + PHONE_DESC_BOB,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/util/ArgumentTokenizerTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/util/ArgumentTokenizerTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -6,10 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ArgumentMultimap;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ArgumentTokenizer;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.Prefix;
 
 public class ArgumentTokenizerTest {
     private final Prefix unknownPrefix = new Prefix("--u");

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/util/ParserUtilTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/util/ParserUtilTest.java
@@ -1,4 +1,4 @@
-package ay2122s1_cs2103t_w16_2.btbb.logic.parser;
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.util;
 
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ParserUtil.MESSAGE_INVALID_INDEX;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import ay2122s1_cs2103t_w16_2.btbb.exception.ParseException;
-import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ParserUtil;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Address;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Email;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Name;

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/order/OrderTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/order/OrderTest.java
@@ -1,0 +1,53 @@
+package ay2122s1_cs2103t_w16_2.btbb.model.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.ORDER_BY_ALICE;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.ORDER_BY_BENSON;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.ORDER_BY_CARL;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.ORDER_BY_DANIEL;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.ORDER_BY_ELLE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderBuilder;
+
+class OrderTest {
+    @Test
+    public void isSameOrder() {
+        // same object -> returns true
+        assertTrue(ORDER_BY_ALICE.equals(ORDER_BY_ALICE));
+
+        // null -> returns false
+        assertFalse(ORDER_BY_BENSON.equals(null));
+
+        // different phone -> returns false
+        Order editedRandomOrder = new OrderBuilder(ORDER_BY_CARL).withPhone(new Phone(VALID_PHONE_BOB)).build();
+        assertFalse(ORDER_BY_CARL.equals(editedRandomOrder));
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        Order randomOrderCopy = new OrderBuilder(ORDER_BY_DANIEL).build();
+        assertTrue(ORDER_BY_DANIEL.equals(randomOrderCopy));
+
+        // same object -> returns true
+        assertTrue(ORDER_BY_ALICE.equals(ORDER_BY_ALICE));
+
+        // null -> returns false
+        assertFalse(ORDER_BY_ALICE.equals(null));
+
+        // different type -> returns false
+        assertFalse(ORDER_BY_ALICE.equals(5));
+
+        // different order -> returns false
+        assertFalse(ORDER_BY_ALICE.equals(ORDER_BY_ELLE));
+
+        // different phone -> returns false
+        Order editedRandomOrder = new OrderBuilder(ORDER_BY_CARL).withPhone(new Phone(VALID_PHONE_BOB)).build();
+        assertFalse(ORDER_BY_CARL.equals(editedRandomOrder));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/order/OrderTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/order/OrderTest.java
@@ -31,8 +31,8 @@ class OrderTest {
     @Test
     public void equals() {
         // same values -> returns true
-        Order randomOrderCopy = new OrderBuilder(ORDER_BY_DANIEL).build();
-        assertTrue(ORDER_BY_DANIEL.equals(randomOrderCopy));
+        Order orderCopy = new OrderBuilder(ORDER_BY_DANIEL).build();
+        assertTrue(ORDER_BY_DANIEL.equals(orderCopy));
 
         // same object -> returns true
         assertTrue(ORDER_BY_ALICE.equals(ORDER_BY_ALICE));
@@ -47,7 +47,7 @@ class OrderTest {
         assertFalse(ORDER_BY_ALICE.equals(ORDER_BY_ELLE));
 
         // different phone -> returns false
-        Order editedRandomOrder = new OrderBuilder(ORDER_BY_CARL).withPhone(new Phone(VALID_PHONE_BOB)).build();
-        assertFalse(ORDER_BY_CARL.equals(editedRandomOrder));
+        Order editedOrder = new OrderBuilder(ORDER_BY_CARL).withPhone(new Phone(VALID_PHONE_BOB)).build();
+        assertFalse(ORDER_BY_CARL.equals(editedOrder));
     }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/order/UniqueOrderListTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/order/UniqueOrderListTest.java
@@ -1,0 +1,53 @@
+package ay2122s1_cs2103t_w16_2.btbb.model.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.ORDER_BY_ALICE;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.ORDER_BY_BOB;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class UniqueOrderListTest {
+    private final UniqueOrderList uniqueOrderList = new UniqueOrderList();
+
+    @Test
+    public void contains_nullOrder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.contains(null));
+    }
+
+    @Test
+    public void contains_orderNotInList_returnsFalse() {
+        assertFalse(uniqueOrderList.contains(ORDER_BY_ALICE));
+    }
+
+    @Test
+    public void contains_orderInList_returnsTrue() {
+        uniqueOrderList.add(ORDER_BY_ALICE);
+        assertTrue(uniqueOrderList.contains(ORDER_BY_ALICE));
+    }
+
+    @Test
+    public void add_nullOrder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.add(null));
+    }
+
+    @Test
+    public void setOrders_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.setOrders((List<Order>) null));
+    }
+
+    @Test
+    public void setOrders_list_replacesOwnListWithProvidedList() {
+        uniqueOrderList.add(ORDER_BY_ALICE);
+        List<Order> orderList = Collections.singletonList(ORDER_BY_BOB);
+        uniqueOrderList.setOrders(orderList);
+        UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
+        expectedUniqueOrderList.add(ORDER_BY_BOB);
+        assertEquals(expectedUniqueOrderList, uniqueOrderList);
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/storage/JsonAdaptedOrderTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/storage/JsonAdaptedOrderTest.java
@@ -1,0 +1,36 @@
+package ay2122s1_cs2103t_w16_2.btbb.storage;
+
+import static ay2122s1_cs2103t_w16_2.btbb.storage.JsonAdaptedOrder.MISSING_FIELD_MESSAGE_FORMAT;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.ORDER_BY_BENSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.exception.IllegalValueException;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+
+public class JsonAdaptedOrderTest {
+    private static final String INVALID_PHONE = "+651234";
+
+    @Test
+    public void toModelType_validOrderDetails_returnsOrder() throws IllegalValueException {
+        JsonAdaptedOrder order = new JsonAdaptedOrder(ORDER_BY_BENSON);
+        assertEquals(ORDER_BY_BENSON, order.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidPhone_throwsIllegalValueException() {
+        JsonAdaptedOrder order = new JsonAdaptedOrder(INVALID_PHONE);
+        String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullPhone_throwsIllegalValueException() {
+        // Type cast here to avoid conflict with the other JsonAdaptedOrder constructor
+        JsonAdaptedOrder order = new JsonAdaptedOrder((String) null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/OrderBuilder.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/OrderBuilder.java
@@ -1,0 +1,44 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+
+/**
+ * A utility class to help with building Order objects.
+ */
+public class OrderBuilder {
+    private static final String DEFAULT_PHONE = "85355255";
+
+    private Phone clientPhone;
+
+    /**
+     * Creates a {@code OrderBuilder} with the default details.
+     */
+    public OrderBuilder() {
+        clientPhone = new Phone(DEFAULT_PHONE);
+    }
+
+    /**
+     * Initializes the OrderBuilder with the data of {@code orderToCopy}.
+     *
+     * @param orderToCopy The data from which to copy from to create a new order.
+     */
+    public OrderBuilder(Order orderToCopy) {
+        clientPhone = orderToCopy.getClientPhone();
+    }
+
+    /**
+     * Sets the {@code clientPhone} of the {@code OrderBuilder} that we are building.
+     *
+     * @param clientPhone The client's phone associated with the order we are building.
+     * @return The {@code OrderBuilder} object.
+     */
+    public OrderBuilder withPhone(Phone clientPhone) {
+        this.clientPhone = clientPhone;
+        return this;
+    }
+
+    public Order build() {
+        return new Order(clientPhone);
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/OrderDescriptorBuilder.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/OrderDescriptorBuilder.java
@@ -1,0 +1,53 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil;
+
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.OrderDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Phone;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+
+/**
+ * A utility class to help with building OrderDescriptorBuilder objects.
+ */
+public class OrderDescriptorBuilder {
+    private OrderDescriptor descriptor;
+
+    /**
+     * Creates an empty {@code OrderDescriptorBuilder}.
+     */
+    public OrderDescriptorBuilder() {
+        descriptor = new OrderDescriptor();
+    }
+
+    /**
+     * Initializes the OrderDescriptorBuilder with the data of {@code descriptor}.
+     *
+     * @param descriptor The data from which to copy from to create a new order descriptor.
+     */
+    public OrderDescriptorBuilder(OrderDescriptor descriptor) {
+        this.descriptor = new OrderDescriptor(descriptor);
+    }
+
+    /**
+     * Returns a {@code OrderDescriptor} with fields containing {@code order}'s details
+     *
+     * @param order The order from which to copy from to create a new order descriptor.
+     */
+    public OrderDescriptorBuilder(Order order) {
+        descriptor = new OrderDescriptor();
+        descriptor.setPhone(order.getClientPhone());
+    }
+
+    /**
+     * Sets the {@code Phone} of the {@code OrderDescriptor} that we are building.
+     *
+     * @param phone The phone that should be set.
+     * @return A OrderDescriptorBuilder object that contains the new phone details.
+     */
+    public OrderDescriptorBuilder withPhone(String phone) {
+        descriptor.setPhone(new Phone(phone));
+        return this;
+    }
+
+    public OrderDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/TypicalOrders.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/TypicalOrders.java
@@ -1,0 +1,30 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil;
+
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.ALICE;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.AMY;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.BENSON;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.BOB;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.CARL;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.DANIEL;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.ELLE;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.FIONA;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalClients.GEORGE;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+
+/**
+ * A utility class containing a list of {@code Order} objects to be used in tests.
+ */
+public class TypicalOrders {
+    public static final Order ORDER_BY_ALICE = new OrderBuilder().withPhone(ALICE.getPhone()).build();
+    public static final Order ORDER_BY_BENSON = new OrderBuilder().withPhone(BENSON.getPhone()).build();
+    public static final Order ORDER_BY_CARL = new OrderBuilder().withPhone(CARL.getPhone()).build();
+    public static final Order ORDER_BY_DANIEL = new OrderBuilder().withPhone(DANIEL.getPhone()).build();
+    public static final Order ORDER_BY_ELLE = new OrderBuilder().withPhone(ELLE.getPhone()).build();
+    public static final Order ORDER_BY_FIONA = new OrderBuilder().withPhone(FIONA.getPhone()).build();
+    public static final Order ORDER_BY_GEORGE = new OrderBuilder().withPhone(GEORGE.getPhone()).build();
+
+    // Manually added - Order's details found in {@code TypicalClients} and {@code CommandTestUtil}
+    public static final Order ORDER_BY_AMY = new OrderBuilder().withPhone(AMY.getPhone()).build();
+    public static final Order ORDER_BY_BOB = new OrderBuilder().withPhone(BOB.getPhone()).build();
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStub.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStub.java
@@ -1,0 +1,102 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil.stubs;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.GuiSettings;
+import ay2122s1_cs2103t_w16_2.btbb.model.Model;
+import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyAddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyUserPrefs;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+import javafx.collections.ObservableList;
+
+/**
+ * A default model stub that has all of its methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBookFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBook(ReadOnlyAddressBook newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredOrderList(Predicate<Order> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addClient(Client client) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasClient(Client client) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteClient(Client target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setClient(Client target, Client editedClient) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Client> getFilteredClientList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredClientList(Predicate<Client> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addOrder(Order order) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasOrder(Order order) {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubAcceptingClientAdded.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubAcceptingClientAdded.java
@@ -1,0 +1,37 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil.stubs;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyAddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
+
+/**
+ * A Model stub that always accepts the client being added.
+ */
+public class ModelStubAcceptingClientAdded extends ModelStub {
+    private final ArrayList<Client> clientsAdded = new ArrayList<>();
+
+    public ArrayList<Client> getClientsAdded() {
+        return clientsAdded;
+    }
+
+    @Override
+    public boolean hasClient(Client client) {
+        requireNonNull(client);
+        return clientsAdded.stream().anyMatch(client::isSameClient);
+    }
+
+    @Override
+    public void addClient(Client client) {
+        requireNonNull(client);
+        clientsAdded.add(client);
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        return new AddressBook();
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubAcceptingOrderAdded.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubAcceptingOrderAdded.java
@@ -1,0 +1,37 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil.stubs;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.ReadOnlyAddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+
+/**
+ * A Model stub that always accepts the order being added.
+ */
+public class ModelStubAcceptingOrderAdded extends ModelStub {
+    private final ArrayList<Order> ordersAdded = new ArrayList<>();
+
+    public ArrayList<Order> getOrdersAdded() {
+        return ordersAdded;
+    }
+
+    @Override
+    public boolean hasOrder(Order order) {
+        requireNonNull(order);
+        return ordersAdded.stream().anyMatch(order::isSameOrder);
+    }
+
+    @Override
+    public void addOrder(Order order) {
+        requireNonNull(order);
+        ordersAdded.add(order);
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        return new AddressBook();
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubWithClient.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStubWithClient.java
@@ -1,0 +1,28 @@
+package ay2122s1_cs2103t_w16_2.btbb.testutil.stubs;
+
+import static java.util.Objects.requireNonNull;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
+
+/**
+ * A Model stub that contains a single client.
+ */
+public class ModelStubWithClient extends ModelStub {
+    private final Client client;
+
+    /**
+     * Constructs a ModelStubWithClient object which contains the given client.
+     *
+     * @param client The client that this model should contain.
+     */
+    public ModelStubWithClient(Client client) {
+        requireNonNull(client);
+        this.client = client;
+    }
+
+    @Override
+    public boolean hasClient(Client client) {
+        requireNonNull(client);
+        return this.client.isSameClient(client);
+    }
+}


### PR DESCRIPTION
# Changes
- Reorganised test packages so that it mirrors the main package.
- Added new tests for all exception classes in the project.
- Added all order related test (e.g. `AddOrderCommandTest`, `OrderTest`, etc)
   - Note that more tests will be added to these files as more features gets implemented.
- Implemented several methods in the main package to support the newly added tests.
- Added `OrderBuilder`, `OrderDescriptorBuilder`, `TypicalOrders` which can be used for future order related test cases.

Closes https://github.com/AY2122S1-CS2103T-W16-2/tp/issues/58