### PR TITLE
Implement Add order ingredient & Edit order ingredient

### DIFF
--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/commons/core/Messages.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The client index provided is invalid";
     public static final String MESSAGE_INVALID_INGREDIENT_DISPLAYED_INDEX = "The ingredient index provided is invalid";
+    public static final String MESSAGE_INVALID_ORDER_DISPLAYED_INDEX = "The order index provided is invalid";
     public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d clients listed!";
     public static final String MESSAGE_INGREDIENTS_LISTED_OVERVIEW = "%1$d ingredients listed!";
     public static final String MESSAGE_ORDERS_LISTED_OVERVIEW = "%1$d orders listed!";

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderIngredientCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderIngredientCommand.java
@@ -1,0 +1,109 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.commons.util.CollectionUtil.requireAllNonNull;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_NAME;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_QUANTITY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_UNIT;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
+import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
+import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.Command;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.IngredientDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.OrderDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.Model;
+import ay2122s1_cs2103t_w16_2.btbb.model.ingredient.Ingredient;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.RecipeIngredientList;
+import ay2122s1_cs2103t_w16_2.btbb.ui.UiTab;
+
+/**
+ * Adds an ingredient to an existing order in btbb.
+ */
+public class AddOrderIngredientCommand extends Command {
+    public static final String COMMAND_WORD = "add-oi";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an ingredient to the order identified "
+            + "by the index number used in the displayed order list.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_INGREDIENT_NAME + "NAME "
+            + PREFIX_INGREDIENT_QUANTITY + "QUANTITY "
+            + PREFIX_INGREDIENT_UNIT + "UNIT\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_INGREDIENT_NAME + "Rice "
+            + PREFIX_INGREDIENT_QUANTITY + "400 "
+            + PREFIX_INGREDIENT_UNIT + "g";
+
+    public static final String MESSAGE_ADD_ORDER_INGREDIENT_SUCCESS = "Added Ingredient to Order: %1$s";
+    public static final String MESSAGE_DUPLICATE_ORDER = "This order already exists in btbb.";
+    public static final String MESSAGE_DUPLICATE_ORDER_INGREDIENT = "This ingredient already exists in the order";
+
+    private final Index index;
+    private final IngredientDescriptor ingredientDescriptor;
+
+    /**
+     * Creates an AddOrderIngredientCommand to add the specified {@code Ingredient}.
+     *
+     * @param index of the order in the filtered order list.
+     * @param ingredientDescriptor of ingredient to add to the order.
+     */
+    public AddOrderIngredientCommand(Index index, IngredientDescriptor ingredientDescriptor) {
+        requireAllNonNull(index, ingredientDescriptor);
+
+        this.index = index;
+        this.ingredientDescriptor = ingredientDescriptor;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Order> lastShownList = model.getFilteredOrderList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+        }
+
+        Ingredient ingredientToAdd = ingredientDescriptor.toModelType();
+        Order orderToEdit = lastShownList.get(index.getZeroBased());
+
+        RecipeIngredientList editedIngredientList = makeEditedIngredientList(ingredientToAdd, orderToEdit);
+        Order editedOrder = makeEditedOrder(editedIngredientList, orderToEdit);
+        if (!orderToEdit.isSameOrder(editedOrder) && model.hasOrder(editedOrder)) {
+            throw new CommandException(MESSAGE_DUPLICATE_ORDER);
+        }
+
+        model.minusIngredientQuantity(ingredientToAdd, editedOrder.getQuantity());
+
+        try {
+            model.setOrder(orderToEdit, editedOrder);
+        } catch (NotFoundException e) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+        }
+
+        return new CommandResult(String.format(MESSAGE_ADD_ORDER_INGREDIENT_SUCCESS, editedOrder), UiTab.HOME);
+    }
+
+    private RecipeIngredientList makeEditedIngredientList(Ingredient ingredientToAdd, Order orderToEdit)
+            throws CommandException {
+        RecipeIngredientList originalRecipeIngredientList = orderToEdit.getRecipeIngredients();
+        if (originalRecipeIngredientList.contains(ingredientToAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_ORDER_INGREDIENT);
+        }
+
+        List<Ingredient> newIngredients = new ArrayList<>(originalRecipeIngredientList.getIngredients());
+        newIngredients.add(ingredientToAdd);
+        return new RecipeIngredientList(newIngredients);
+    }
+
+    private Order makeEditedOrder(RecipeIngredientList editedIngredientList, Order orderToEdit) {
+        OrderDescriptor orderDescriptor = new OrderDescriptor();
+        orderDescriptor.setRecipeIngredients(editedIngredientList);
+        return orderDescriptor.toModelTypeFrom(orderToEdit);
+    }
+}

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderIngredientCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderIngredientCommand.java
@@ -102,4 +102,22 @@ public class AddOrderIngredientCommand extends Command {
         newIngredients.add(ingredientToAdd);
         return new RecipeIngredientList(newIngredients);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddOrderIngredientCommand)) {
+            return false;
+        }
+
+        // state check
+        AddOrderIngredientCommand e = (AddOrderIngredientCommand) other;
+        return index.equals(e.index)
+                && ingredientDescriptor.equals(e.ingredientDescriptor);
+    }
 }

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderIngredientCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderIngredientCommand.java
@@ -1,6 +1,8 @@
 package ay2122s1_cs2103t_w16_2.btbb.logic.commands.order;
 
 import static ay2122s1_cs2103t_w16_2.btbb.commons.util.CollectionUtil.requireAllNonNull;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderCommand.MESSAGE_DUPLICATE_ORDER;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.util.CommandUtil.makeOrderWithEditedIngredients;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_NAME;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_QUANTITY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_UNIT;
@@ -16,7 +18,6 @@ import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.Command;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.IngredientDescriptor;
-import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.OrderDescriptor;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.ingredient.Ingredient;
 import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
@@ -40,8 +41,8 @@ public class AddOrderIngredientCommand extends Command {
             + PREFIX_INGREDIENT_QUANTITY + "400 "
             + PREFIX_INGREDIENT_UNIT + "g";
 
-    public static final String MESSAGE_ADD_ORDER_INGREDIENT_SUCCESS = "Added Ingredient to Order: %1$s";
-    public static final String MESSAGE_DUPLICATE_ORDER = "This order already exists in btbb.";
+    public static final String MESSAGE_ADD_ORDER_INGREDIENT_SUCCESS = "Added Order Ingredient: %1$s\n"
+            + "Edited Order: %2$s";
     public static final String MESSAGE_DUPLICATE_ORDER_INGREDIENT = "This ingredient already exists in the order";
 
     private final Index index;
@@ -73,7 +74,7 @@ public class AddOrderIngredientCommand extends Command {
         Order orderToEdit = lastShownList.get(index.getZeroBased());
 
         RecipeIngredientList editedIngredientList = makeEditedIngredientList(ingredientToAdd, orderToEdit);
-        Order editedOrder = makeEditedOrder(editedIngredientList, orderToEdit);
+        Order editedOrder = makeOrderWithEditedIngredients(editedIngredientList, orderToEdit);
         if (!orderToEdit.isSameOrder(editedOrder) && model.hasOrder(editedOrder)) {
             throw new CommandException(MESSAGE_DUPLICATE_ORDER);
         }
@@ -86,7 +87,8 @@ public class AddOrderIngredientCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
         }
 
-        return new CommandResult(String.format(MESSAGE_ADD_ORDER_INGREDIENT_SUCCESS, editedOrder), UiTab.HOME);
+        return new CommandResult(
+                String.format(MESSAGE_ADD_ORDER_INGREDIENT_SUCCESS, ingredientToAdd, editedOrder), UiTab.HOME);
     }
 
     private RecipeIngredientList makeEditedIngredientList(Ingredient ingredientToAdd, Order orderToEdit)
@@ -99,11 +101,5 @@ public class AddOrderIngredientCommand extends Command {
         List<Ingredient> newIngredients = new ArrayList<>(originalRecipeIngredientList.getIngredients());
         newIngredients.add(ingredientToAdd);
         return new RecipeIngredientList(newIngredients);
-    }
-
-    private Order makeEditedOrder(RecipeIngredientList editedIngredientList, Order orderToEdit) {
-        OrderDescriptor orderDescriptor = new OrderDescriptor();
-        orderDescriptor.setRecipeIngredients(editedIngredientList);
-        return orderDescriptor.toModelTypeFrom(orderToEdit);
     }
 }

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/DeleteOrderIngredientCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/DeleteOrderIngredientCommand.java
@@ -99,4 +99,22 @@ public class DeleteOrderIngredientCommand extends Command {
 
         return new RecipeIngredientList(newIngredients);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteOrderIngredientCommand)) {
+            return false;
+        }
+
+        // state check
+        DeleteOrderIngredientCommand e = (DeleteOrderIngredientCommand) other;
+        return targetIngredientIndex.equals(e.targetIngredientIndex)
+                && targetOrderIndex.equals(e.targetOrderIndex);
+    }
 }

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/DeleteOrderIngredientCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/DeleteOrderIngredientCommand.java
@@ -1,0 +1,102 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderCommand.MESSAGE_DUPLICATE_ORDER;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.util.CommandUtil.makeOrderWithEditedIngredients;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_INDEX;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
+import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
+import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.Command;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
+import ay2122s1_cs2103t_w16_2.btbb.model.Model;
+import ay2122s1_cs2103t_w16_2.btbb.model.ingredient.Ingredient;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.RecipeIngredientList;
+import ay2122s1_cs2103t_w16_2.btbb.ui.UiTab;
+
+/**
+ * Deletes an ingredient from an existing order in btbb.
+ */
+public class DeleteOrderIngredientCommand extends Command {
+    public static final String COMMAND_WORD = "delete-oi";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the ingredient identified by the index number in an order identified by an index number.\n"
+            + "Parameters: ORDER_INDEX (must be a positive integer) "
+            + PREFIX_INGREDIENT_INDEX + "INGREDIENT_INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_INGREDIENT_INDEX + "2";
+
+    public static final String MESSAGE_DELETE_ORDER_INGREDIENT_SUCCESS = "Deleted Order Ingredient: %1$s\n"
+            + "Edited Order: %2$s";
+
+    private final Index targetIngredientIndex;
+    private final Index targetOrderIndex;
+
+    /**
+     * Creates an DeleteOrderIngredientCommand to delete the specified ingredient,
+     * identified by its index in the order ingredient list.
+     *
+     * @param targetIngredientIndex Index of ingredient in the order ingredient list.
+     * @param targetOrderIndex Index of the order in the displayed list.
+     */
+    public DeleteOrderIngredientCommand(Index targetIngredientIndex, Index targetOrderIndex) {
+        this.targetIngredientIndex = targetIngredientIndex;
+        this.targetOrderIndex = targetOrderIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Order> lastShownOrderList = model.getFilteredOrderList();
+
+        if (targetOrderIndex.getZeroBased() >= lastShownOrderList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+        }
+
+        Order orderToEdit = lastShownOrderList.get(targetOrderIndex.getZeroBased());
+        Ingredient ingredientToDelete = getIngredientToDelete(orderToEdit);
+
+        RecipeIngredientList editedIngredientList = makeEditedIngredientList(orderToEdit);
+        Order editedOrder = makeOrderWithEditedIngredients(editedIngredientList, orderToEdit);
+        if (!orderToEdit.isSameOrder(editedOrder) && model.hasOrder(editedOrder)) {
+            throw new CommandException(MESSAGE_DUPLICATE_ORDER);
+        }
+
+        model.addIngredientQuantity(ingredientToDelete, editedOrder.getQuantity());
+
+        try {
+            model.setOrder(orderToEdit, editedOrder);
+        } catch (NotFoundException e) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+        }
+
+        return new CommandResult(
+                String.format(MESSAGE_DELETE_ORDER_INGREDIENT_SUCCESS, ingredientToDelete, editedOrder), UiTab.HOME);
+    }
+
+    private Ingredient getIngredientToDelete(Order orderToEdit) throws CommandException {
+        RecipeIngredientList originalRecipeIngredientList = orderToEdit.getRecipeIngredients();
+
+        if (targetIngredientIndex.getZeroBased() >= originalRecipeIngredientList.getIngredients().size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_INGREDIENT_DISPLAYED_INDEX);
+        }
+
+        return originalRecipeIngredientList.getIngredients().get(targetIngredientIndex.getZeroBased());
+    }
+
+    private RecipeIngredientList makeEditedIngredientList(Order orderToEdit) {
+        RecipeIngredientList originalRecipeIngredientList = orderToEdit.getRecipeIngredients();
+
+        List<Ingredient> newIngredients = new ArrayList<>(originalRecipeIngredientList.getIngredients());
+        newIngredients.remove(targetIngredientIndex.getZeroBased());
+
+        return new RecipeIngredientList(newIngredients);
+    }
+}

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/util/CommandUtil.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/util/CommandUtil.java
@@ -1,0 +1,23 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.util;
+
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.OrderDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.RecipeIngredientList;
+
+/**
+ * Contains utility methods used for commands in the various *Command classes.
+ */
+public class CommandUtil {
+    /**
+     * Makes a new order with edited ingredients.
+     *
+     * @param editedIngredientList Edited ingredient list.
+     * @param orderToEdit Original order to edit.
+     * @return A new order with edited ingredients while other order fields are the same as the original order.
+     */
+    public static Order makeOrderWithEditedIngredients(RecipeIngredientList editedIngredientList, Order orderToEdit) {
+        OrderDescriptor orderDescriptor = new OrderDescriptor();
+        orderDescriptor.setRecipeIngredients(editedIngredientList);
+        return orderDescriptor.toModelTypeFrom(orderToEdit);
+    }
+}

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/OrderDescriptor.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/descriptors/OrderDescriptor.java
@@ -31,10 +31,10 @@ public class OrderDescriptor {
     private Phone clientPhone;
     private Address clientAddress;
     private GenericString recipeName;
-    private RecipeIngredientList recipeIngredients = new RecipeIngredientList(new ArrayList<>());
+    private RecipeIngredientList recipeIngredients;
     private Price price;
     private Deadline deadline;
-    private Quantity quantity = new Quantity("1");
+    private Quantity quantity;
 
     public OrderDescriptor() {};
 
@@ -99,8 +99,8 @@ public class OrderDescriptor {
         this.recipeIngredients = recipeIngredients;
     }
 
-    public RecipeIngredientList getRecipeIngredients() {
-        return recipeIngredients;
+    public Optional<RecipeIngredientList> getRecipeIngredients() {
+        return Optional.ofNullable(recipeIngredients);
     }
 
     public void setPrice(Price price) {
@@ -123,8 +123,8 @@ public class OrderDescriptor {
         this.quantity = quantity;
     }
 
-    public Quantity getQuantity() {
-        return quantity;
+    public Optional<Quantity> getQuantity() {
+        return Optional.ofNullable(quantity);
     }
 
     /**
@@ -141,11 +141,36 @@ public class OrderDescriptor {
             GenericString clientName = getClientName().orElseGet(() -> client.get().getName());
             Phone clientPhone = getClientPhone().orElseGet(() -> client.get().getPhone());
             Address clientAddress = getClientAddress().orElseGet(() -> client.get().getAddress());
+            Quantity quantity = getQuantity().orElse(new Quantity("1"));
+            RecipeIngredientList recipeIngredientList =
+                    getRecipeIngredients().orElse(new RecipeIngredientList(new ArrayList<>()));
             return new Order(clientName, clientPhone, clientAddress,
-                    recipeName, recipeIngredients, price, deadline, quantity);
+                    recipeName, recipeIngredientList, price, deadline, quantity);
         } catch (NoSuchElementException e) {
             throw new CommandException(MESSAGE_MISSING_CLIENT_DETAILS);
         }
+    }
+
+    /**
+     * Converts an Order Descriptor to an Order model type.
+     * Missing fields are filled with an existing order.
+     *
+     * @param existingOrder An existing Order that is not null.
+     * @return {@code Order}.
+     */
+    public Order toModelTypeFrom(Order existingOrder) {
+        assert existingOrder != null;
+
+        GenericString clientName = getClientName().orElse(existingOrder.getClientName());
+        Phone clientPhone = getClientPhone().orElse(existingOrder.getClientPhone());
+        Address clientAddress = getClientAddress().orElse(existingOrder.getClientAddress());
+        GenericString recipeName = getRecipeName().orElse(existingOrder.getRecipeName());
+        RecipeIngredientList recipeIngredientList = getRecipeIngredients().orElse(existingOrder.getRecipeIngredients());
+        Price price = getPrice().orElse(existingOrder.getPrice());
+        Deadline deadline = getDeadline().orElse(existingOrder.getDeadline());
+        Quantity quantity = getQuantity().orElse(existingOrder.getQuantity());
+        return new Order(clientName, clientPhone, clientAddress,
+                recipeName, recipeIngredientList, price, deadline, quantity);
     }
 
     public Optional<Client> getClientFromModel(Model model) throws CommandException {

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/AddressBookParser.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/AddressBookParser.java
@@ -22,6 +22,7 @@ import ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient.EditIngredientComma
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient.FindIngredientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient.ListIngredientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderIngredientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.FindOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.ListOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.client.AddClientCommandParser;
@@ -34,6 +35,7 @@ import ay2122s1_cs2103t_w16_2.btbb.logic.parser.ingredient.DeleteIngredientComma
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.ingredient.EditIngredientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.ingredient.FindIngredientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.order.AddOrderCommandParser;
+import ay2122s1_cs2103t_w16_2.btbb.logic.parser.order.AddOrderIngredientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.order.FindOrderCommandParser;
 
 /**
@@ -70,6 +72,9 @@ public class AddressBookParser {
 
         case AddOrderCommand.COMMAND_WORD:
             return new AddOrderCommandParser().parse(arguments);
+
+        case AddOrderIngredientCommand.COMMAND_WORD:
+            return new AddOrderIngredientCommandParser().parse(arguments);
 
         case DeleteClientCommand.COMMAND_WORD:
             return new DeleteClientCommandParser().parse(arguments);

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/AddressBookParser.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/AddressBookParser.java
@@ -23,6 +23,7 @@ import ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient.FindIngredientComma
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient.ListIngredientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderIngredientCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.DeleteOrderIngredientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.FindOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.ListOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.client.AddClientCommandParser;
@@ -36,6 +37,7 @@ import ay2122s1_cs2103t_w16_2.btbb.logic.parser.ingredient.EditIngredientCommand
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.ingredient.FindIngredientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.order.AddOrderCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.order.AddOrderIngredientCommandParser;
+import ay2122s1_cs2103t_w16_2.btbb.logic.parser.order.DeleteOrderIngredientCommandParser;
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.order.FindOrderCommandParser;
 
 /**
@@ -75,6 +77,9 @@ public class AddressBookParser {
 
         case AddOrderIngredientCommand.COMMAND_WORD:
             return new AddOrderIngredientCommandParser().parse(arguments);
+
+        case DeleteOrderIngredientCommand.COMMAND_WORD:
+            return new DeleteOrderIngredientCommandParser().parse(arguments);
 
         case DeleteClientCommand.COMMAND_WORD:
             return new DeleteClientCommandParser().parse(arguments);

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/AddOrderIngredientCommandParser.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/AddOrderIngredientCommandParser.java
@@ -1,0 +1,58 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_NAME;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_QUANTITY;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_UNIT;
+import static java.util.Objects.requireNonNull;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
+import ay2122s1_cs2103t_w16_2.btbb.exception.ParseException;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderIngredientCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.IngredientDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.logic.parser.Parser;
+import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ArgumentMultimap;
+import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ArgumentTokenizer;
+import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ParserUtil;
+
+/**
+ * Parses input arguments and creates a new AddOrderIngredientCommand object.
+ */
+public class AddOrderIngredientCommandParser implements Parser<AddOrderIngredientCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddOrderIngredientCommand
+     * and returns an AddOrderIngredientCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    @Override
+    public AddOrderIngredientCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_INGREDIENT_NAME, PREFIX_INGREDIENT_QUANTITY, PREFIX_INGREDIENT_UNIT);
+
+        if (!ParserUtil.areAllPrefixesPresent(argMultimap,
+                PREFIX_INGREDIENT_NAME, PREFIX_INGREDIENT_QUANTITY, PREFIX_INGREDIENT_UNIT)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddOrderIngredientCommand.MESSAGE_USAGE));
+        }
+
+        IngredientDescriptor ingredientDescriptor = new IngredientDescriptor();
+        ingredientDescriptor.setName(ParserUtil.parseGenericString(
+                argMultimap.getValue(PREFIX_INGREDIENT_NAME).get(), "Name"));
+        ingredientDescriptor.setQuantity(ParserUtil.parseQuantity(
+                argMultimap.getValue(PREFIX_INGREDIENT_QUANTITY).get()));
+        ingredientDescriptor.setUnit(ParserUtil.parseGenericString(argMultimap.getValue(PREFIX_INGREDIENT_UNIT).get(),
+                "Unit"));
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderIngredientCommand.MESSAGE_USAGE), pe);
+        }
+
+        return new AddOrderIngredientCommand(index, ingredientDescriptor);
+    }
+}

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/DeleteOrderIngredientCommandParser.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/DeleteOrderIngredientCommandParser.java
@@ -1,0 +1,38 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_INDEX;
+import static java.util.Objects.requireNonNull;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
+import ay2122s1_cs2103t_w16_2.btbb.exception.ParseException;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.DeleteOrderIngredientCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.parser.Parser;
+import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ArgumentMultimap;
+import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ArgumentTokenizer;
+import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ParserUtil;
+
+public class DeleteOrderIngredientCommandParser implements Parser<DeleteOrderIngredientCommand> {
+    @Override
+    public DeleteOrderIngredientCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INGREDIENT_INDEX);
+
+        if (!ParserUtil.areAllPrefixesPresent(argMultimap, PREFIX_INGREDIENT_INDEX)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeleteOrderIngredientCommand.MESSAGE_USAGE));
+        }
+
+        Index ingredientIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INGREDIENT_INDEX).get());
+        Index orderIndex;
+
+        try {
+            orderIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteOrderIngredientCommand.MESSAGE_USAGE), pe);
+        }
+
+        return new DeleteOrderIngredientCommand(ingredientIndex, orderIndex);
+    }
+}

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/util/CliSyntax.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/util/CliSyntax.java
@@ -10,6 +10,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_CLIENT_PHONE = new Prefix("cp/");
     public static final Prefix PREFIX_CLIENT_EMAIL = new Prefix("ce/");
     public static final Prefix PREFIX_CLIENT_ADDRESS = new Prefix("ca/");
+    public static final Prefix PREFIX_INGREDIENT_INDEX = new Prefix("i/");
     public static final Prefix PREFIX_INGREDIENT_NAME = new Prefix("in/");
     public static final Prefix PREFIX_INGREDIENT_QUANTITY = new Prefix("iq/");
     public static final Prefix PREFIX_INGREDIENT_QUANTITY_FROM = new Prefix("iqf/");

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/AddressBook.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/AddressBook.java
@@ -149,6 +149,18 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the similar ingredient that is in the address book with a new ingredient whose quantity is increased
+     * by the quantity in {@code target} if it exists.
+     *
+     * @param target The target ingredient.
+     * @param multiplier The multiplier.
+     */
+    public void addIngredientQuantity(Ingredient target, Quantity multiplier) {
+        requireAllNonNull(target, multiplier);
+        ingredients.addIngredientQuantity(target, multiplier);
+    }
+
+    /**
      * Returns true if an ingredient with the same identity as {@code ingredient} exists in the address book.
      *
      * @param ingredient to check.

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/AddressBook.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/AddressBook.java
@@ -213,6 +213,19 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(order);
         return orders.contains(order);
     }
+
+    /**
+     * Replaces the existing target Order in the address book with an edited Order.
+     *
+     * @param target The target order to replace.
+     * @param editedOrder The edited order to replace with.
+     * @throws NotFoundException if the target order does not exist in the address book.
+     */
+    public void setOrder(Order target, Order editedOrder) throws NotFoundException {
+        requireAllNonNull(target, editedOrder);
+        orders.setOrder(target, editedOrder);
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/Model.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/Model.java
@@ -163,6 +163,13 @@ public interface Model {
      */
     boolean hasOrder(Order order);
 
+    /**
+     * Replaces the given order {@code target} with {@code editedOrder}.
+     * {@code target} must exist in the address book.
+     * The order identity of {@code editedOrder} must not be the same as another existing order in the address book.
+     */
+    void setOrder(Order target, Order editedOrder) throws NotFoundException;
+
     /** Returns an unmodifiable view of the filtered order list */
     ObservableList<Order> getFilteredOrderList();
 

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/Model.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/Model.java
@@ -109,6 +109,14 @@ public interface Model {
     void addIngredient(Ingredient ingredient);
 
     /**
+     * Increases the quantity of the ingredient that is the same as the {@code target} ingredient if it exists.
+     *
+     * @param target The target ingredient.
+     * @param multiplier The multiplier.
+     */
+    void addIngredientQuantity(Ingredient target, Quantity multiplier);
+
+    /**
      * Returns true if an ingredient with the same identity as {@code ingredient} exists in the address book.
      *
      * @param ingredient to check.

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/ModelManager.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/ModelManager.java
@@ -237,6 +237,20 @@ public class ModelManager implements Model {
         return addressBook.hasOrder(order);
     }
 
+    /**
+     * Implements setOrder method.
+     * Replaces the existing Order in the address book with an edited Order.
+     *
+     * @param target The target order to replace.
+     * @param editedOrder The edited order to replace with.
+     * @throws NotFoundException if the target order was not found in the address book.
+     */
+    @Override
+    public void setOrder(Order target, Order editedOrder) throws NotFoundException {
+        requireAllNonNull(target, editedOrder);
+        addressBook.setOrder(target, editedOrder);
+    }
+
     @Override
     public ObservableList<Order> getFilteredOrderList() {
         return filteredOrders;

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/ModelManager.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/ModelManager.java
@@ -151,6 +151,18 @@ public class ModelManager implements Model {
     }
 
     /**
+     * Implements addIngredientQuantity method.
+     *
+     * @param target The target ingredient.
+     * @param multiplier The multiplier.
+     */
+    @Override
+    public void addIngredientQuantity(Ingredient target, Quantity multiplier) {
+        requireAllNonNull(target, multiplier);
+        addressBook.addIngredientQuantity(target, multiplier);
+    }
+
+    /**
      * Implements hasIngredient method.
      * Returns true if an ingredient with the same identity as {@code ingredient} exists in the address book.
      *

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/ingredient/UniqueIngredientList.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/ingredient/UniqueIngredientList.java
@@ -52,6 +52,30 @@ public class UniqueIngredientList implements Iterable<Ingredient> {
     }
 
     /**
+     * Replaces the similar ingredient that is in the address book with a new ingredient whose quantity is increased
+     * by the quantity in {@code target} times the multiplier if it exists.
+     *
+     * @param target The target ingredient.
+     * @param multiplier The multiplier.
+     */
+    public void addIngredientQuantity(Ingredient target, Quantity multiplier) {
+        requireAllNonNull(target, multiplier);
+
+        Ingredient currentIngredient = internalList.stream()
+                .filter(target::isSameIngredient).findFirst().orElse(null);
+
+        if (currentIngredient != null) {
+            Ingredient ingredientWithNewQuantity = new Ingredient(
+                    currentIngredient.getName(),
+                    currentIngredient.getQuantity().addQuantityBy(target.getQuantity(), multiplier),
+                    currentIngredient.getUnit());
+
+            int index = internalList.indexOf(currentIngredient);
+            internalList.set(index, ingredientWithNewQuantity);
+        }
+    }
+
+    /**
      * Replaces the contents of this list with {@code ingredients}.
      * {@code ingredients} must not contain duplicate ingredients.
      *

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/order/RecipeIngredientList.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/order/RecipeIngredientList.java
@@ -30,6 +30,17 @@ public class RecipeIngredientList {
         this.ingredients = ingredients;
     }
 
+    /**
+     * Returns true if the list contains an equivalent ingredient as the given argument.
+     *
+     * @param toCheck Ingredient.
+     * @return true if ingredient is already in the ingredients list, false otherwise.
+     */
+    public boolean contains(Ingredient toCheck) {
+        requireNonNull(toCheck);
+        return ingredients.stream().anyMatch(toCheck::isSameIngredient);
+    }
+
     public List<Ingredient> getIngredients() {
         return ingredients;
     }

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/order/UniqueOrderList.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/order/UniqueOrderList.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Iterator;
 import java.util.List;
 
+import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -30,6 +31,24 @@ public class UniqueOrderList implements Iterable<Order> {
     public boolean contains(Order toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isSameOrder);
+    }
+
+    /**
+     * Replaces the existing target Order in the list with an edited Order
+     *
+     * @param target The target order to replace.
+     * @param editedOrder The edited order to replace with.
+     * @throws NotFoundException if the target Order does not exist in the list.
+     */
+    public void setOrder(Order target, Order editedOrder) throws NotFoundException {
+        requireAllNonNull(target, editedOrder);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new NotFoundException(Order.class.getName());
+        }
+
+        internalList.set(index, editedOrder);
     }
 
     /**

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/shared/Quantity.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/model/shared/Quantity.java
@@ -8,8 +8,10 @@ import static java.util.Objects.requireNonNull;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Quantity implements Comparable<Quantity> {
+    public static final int MIN_QUANTITY = 0;
+    public static final int MAX_QUANTITY = 40000;
     public static final String DEFAULT_MIN_QUANTITY_STRING = String.valueOf(0);
-    public static final String DEFAULT_MAX_QUANTITY_STRING = String.valueOf(40000);
+    public static final String DEFAULT_MAX_QUANTITY_STRING = String.valueOf(MAX_QUANTITY);
     public static final String MESSAGE_CONSTRAINTS =
             "Quantity should only contain numbers, it should be positive "
                     + "and the largest acceptable quantity is 40000.";
@@ -38,7 +40,7 @@ public class Quantity implements Comparable<Quantity> {
     public static boolean isValidQuantity(String test) {
         try {
             int quantity = Integer.parseInt(test);
-            return quantity > 0 && quantity <= 40000;
+            return quantity > MIN_QUANTITY && quantity <= MAX_QUANTITY;
         } catch (NumberFormatException numberFormatException) {
             return false;
         }
@@ -54,10 +56,21 @@ public class Quantity implements Comparable<Quantity> {
     public static boolean isValidInternalQuantity(String test) {
         try {
             int quantity = Integer.parseInt(test);
-            return quantity >= 0 && quantity <= 40000;
+            return quantity >= MIN_QUANTITY && quantity <= MAX_QUANTITY;
         } catch (NumberFormatException numberFormatException) {
             return false;
         }
+    }
+
+    /**
+     * Returns a new {@code Quantity} object with its quantity increased by amount * multiplier.
+     *
+     * @param amount The amount to increase.
+     * @param multiplier The multiplier.
+     * @return A new {@code Quantity} object.
+     */
+    public Quantity addQuantityBy(Quantity amount, Quantity multiplier) {
+        return new Quantity(Integer.toString(Math.min(quantity + amount.quantity * multiplier.quantity, MAX_QUANTITY)));
     }
 
     /**
@@ -68,7 +81,7 @@ public class Quantity implements Comparable<Quantity> {
      * @return A new {@code Quantity} object.
      */
     public Quantity minusQuantityBy(Quantity amount, Quantity multiplier) {
-        return new Quantity(Integer.toString(Math.max(quantity - amount.quantity * multiplier.quantity, 0)));
+        return new Quantity(Integer.toString(Math.max(quantity - amount.quantity * multiplier.quantity, MIN_QUANTITY)));
     }
 
     /**

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/CommandTestUtil.java
@@ -5,6 +5,7 @@ import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_CLI
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_CLIENT_INDEX;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_CLIENT_NAME;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_CLIENT_PHONE;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_INDEX;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_NAME;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_QUANTITY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_QUANTITY_FROM;
@@ -96,6 +97,7 @@ public class CommandTestUtil {
     public static final String INDEX_DESC_BOB = " " + PREFIX_CLIENT_INDEX + INDEX_FIRST.getOneBased();
 
     // Ingredient (valid prefix + valid attributes)
+    public static final String INGREDIENT_INDEX_DESC_FIRST = " " + PREFIX_INGREDIENT_INDEX + "1";
     public static final String INGREDIENT_NAME_DESC_APPLE = " " + PREFIX_INGREDIENT_NAME + VALID_INGREDIENT_NAME_APPLE;
     public static final String INGREDIENT_NAME_DESC_BEEF = " " + PREFIX_INGREDIENT_NAME + VALID_INGREDIENT_NAME_BEEF;
     public static final String QUANTITY_DESC_APPLE = " " + PREFIX_INGREDIENT_QUANTITY + VALID_QUANTITY_APPLE;
@@ -126,6 +128,7 @@ public class CommandTestUtil {
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_CLIENT_ADDRESS; // no empty string for addresses
 
     // Ingredient (valid prefix + invalid attributes)
+    public static final String INVALID_INGREDIENT_INDEX_DESC_FIRST = " " + PREFIX_INGREDIENT_INDEX + "-1";
     public static final String INVALID_INGREDIENT_NAME_DESC = " " + PREFIX_INGREDIENT_NAME + "Rice&"; // '&' not allowed
     public static final String INVALID_QUANTITY_DESC = " " + PREFIX_INGREDIENT_QUANTITY + "-30";
     public static final String INVALID_QUANTITY_FROM_DESC = " " + PREFIX_INGREDIENT_QUANTITY_FROM + "-30";

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/CommandTestUtil.java
@@ -18,7 +18,6 @@ import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_REC
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_FIRST;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_SECOND;
-import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_THIRD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,6 +34,7 @@ import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
 import ay2122s1_cs2103t_w16_2.btbb.model.client.Client;
 import ay2122s1_cs2103t_w16_2.btbb.model.ingredient.Ingredient;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
 import ay2122s1_cs2103t_w16_2.btbb.model.predicate.StringContainsKeywordsPredicate;
 import ay2122s1_cs2103t_w16_2.btbb.model.shared.GenericString;
 import ay2122s1_cs2103t_w16_2.btbb.model.shared.Quantity;
@@ -86,19 +86,14 @@ public class CommandTestUtil {
     // Client (valid prefix + valid attributes)
     public static final String NAME_DESC_AMY = " " + PREFIX_CLIENT_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_CLIENT_NAME + VALID_NAME_BOB;
-    public static final String NAME_DESC_IMRAN = " " + PREFIX_CLIENT_NAME + VALID_NAME_IMRAN;
     public static final String PHONE_DESC_AMY = " " + PREFIX_CLIENT_PHONE + VALID_PHONE_AMY;
     public static final String PHONE_DESC_BOB = " " + PREFIX_CLIENT_PHONE + VALID_PHONE_BOB;
-    public static final String PHONE_DESC_IMRAN = " " + PREFIX_CLIENT_PHONE + VALID_PHONE_IMRAN;
     public static final String EMAIL_DESC_AMY = " " + PREFIX_CLIENT_EMAIL + VALID_EMAIL_AMY;
     public static final String EMAIL_DESC_BOB = " " + PREFIX_CLIENT_EMAIL + VALID_EMAIL_BOB;
-    public static final String EMAIL_DESC_IMRAN = " " + PREFIX_CLIENT_EMAIL + VALID_EMAIL_IMRAN;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_CLIENT_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_CLIENT_ADDRESS + VALID_ADDRESS_BOB;
-    public static final String ADDRESS_DESC_IMRAN = " " + PREFIX_CLIENT_ADDRESS + VALID_ADDRESS_IMRAN;
     public static final String INDEX_DESC_AMY = " " + PREFIX_CLIENT_INDEX + INDEX_SECOND.getOneBased();
     public static final String INDEX_DESC_BOB = " " + PREFIX_CLIENT_INDEX + INDEX_FIRST.getOneBased();
-    public static final String INDEX_DESC_IMRAN = " " + PREFIX_CLIENT_INDEX + INDEX_THIRD.getOneBased();
 
     // Ingredient (valid prefix + valid attributes)
     public static final String INGREDIENT_NAME_DESC_APPLE = " " + PREFIX_INGREDIENT_NAME + VALID_INGREDIENT_NAME_APPLE;
@@ -280,5 +275,18 @@ public class CommandTestUtil {
         model.updateFilteredIngredientList(ingredient -> ingredient.equals(ingredientToShow));
 
         assertEquals(1, model.getFilteredIngredientList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the order at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showOrderAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredOrderList().size());
+
+        Order orderToShow = model.getFilteredOrderList().get(targetIndex.getZeroBased());
+        model.updateFilteredOrderList(order -> order.equals(orderToShow));
+
+        assertEquals(1, model.getFilteredOrderList().size());
     }
 }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderIngredientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderIngredientCommandTest.java
@@ -50,7 +50,7 @@ public class AddOrderIngredientCommandTest {
     }
 
     @Test
-    public void execute_validIngredientAndOrderIndexUnfilteredList_addSuccessful() throws Exception {
+    public void execute_validIngredientAndOrderIndex_addSuccessful() throws Exception {
         Ingredient validIngredient = new IngredientBuilder().build();
         IngredientDescriptor validIngredientDescriptor = new IngredientDescriptorBuilder(validIngredient).build();
         AddOrderIngredientCommand command = new AddOrderIngredientCommand(INDEX_FIRST, validIngredientDescriptor);
@@ -63,28 +63,6 @@ public class AddOrderIngredientCommandTest {
                 AddOrderIngredientCommand.MESSAGE_ADD_ORDER_INGREDIENT_SUCCESS, validIngredient, editedOrder);
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setOrder(orderToEdit, editedOrder);
-
-        assertCommandSuccessWithTabChange(command, model, expectedMessage, expectedModel, UiTab.HOME);
-    }
-
-    @Test
-    public void execute_validIngredientAndOrderIndexFilteredList_addSuccessful() throws Exception {
-        showOrderAtIndex(model, INDEX_FIRST);
-
-        Ingredient validIngredient = new IngredientBuilder().build();
-        IngredientDescriptor validIngredientDescriptor = new IngredientDescriptorBuilder(validIngredient).build();
-        AddOrderIngredientCommand command = new AddOrderIngredientCommand(INDEX_FIRST, validIngredientDescriptor);
-        Order orderInFilteredList = model.getFilteredOrderList().get(INDEX_FIRST.getZeroBased());
-        RecipeIngredientList newRecipeIngredientList =
-                OrderUtil.addIngredientToIngredientList(orderInFilteredList, validIngredient);
-        Order editedOrder =
-                new OrderBuilder(orderInFilteredList).withRecipeIngredients(newRecipeIngredientList).build();
-
-        String expectedMessage = String.format(
-                AddOrderIngredientCommand.MESSAGE_ADD_ORDER_INGREDIENT_SUCCESS, validIngredient, editedOrder);
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        showOrderAtIndex(expectedModel, INDEX_FIRST);
-        expectedModel.setOrder(orderInFilteredList, editedOrder);
 
         assertCommandSuccessWithTabChange(command, model, expectedMessage, expectedModel, UiTab.HOME);
     }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderIngredientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/AddOrderIngredientCommandTest.java
@@ -1,0 +1,169 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_APPLE;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DESC_BEEF;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandFailure;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccessWithTabChange;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.showOrderAtIndex;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_FIRST;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_SECOND;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.getTypicalAddressBook;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.ListClientCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.IngredientDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.Model;
+import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
+import ay2122s1_cs2103t_w16_2.btbb.model.UserPrefs;
+import ay2122s1_cs2103t_w16_2.btbb.model.ingredient.Ingredient;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.RecipeIngredientList;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.IngredientBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.IngredientDescriptorBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderUtil;
+import ay2122s1_cs2103t_w16_2.btbb.ui.UiTab;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for AddOrderIngredientCommand.
+ */
+public class AddOrderIngredientCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new AddOrderIngredientCommand(null, null));
+        assertThrows(NullPointerException.class, () ->
+                new AddOrderIngredientCommand(INDEX_FIRST, null));
+        assertThrows(NullPointerException.class, () ->
+                new AddOrderIngredientCommand(null, new IngredientDescriptor()));
+    }
+
+    @Test
+    public void execute_validIngredientAndOrderIndexUnfilteredList_addSuccessful() throws Exception {
+        Ingredient validIngredient = new IngredientBuilder().build();
+        IngredientDescriptor validIngredientDescriptor = new IngredientDescriptorBuilder(validIngredient).build();
+        AddOrderIngredientCommand command = new AddOrderIngredientCommand(INDEX_FIRST, validIngredientDescriptor);
+        Order orderToEdit = model.getFilteredOrderList().get(INDEX_FIRST.getZeroBased());
+        RecipeIngredientList newRecipeIngredientList =
+                OrderUtil.addIngredientToIngredientList(orderToEdit, validIngredient);
+        Order editedOrder = new OrderBuilder(orderToEdit).withRecipeIngredients(newRecipeIngredientList).build();
+
+        String expectedMessage = String.format(
+                AddOrderIngredientCommand.MESSAGE_ADD_ORDER_INGREDIENT_SUCCESS, validIngredient, editedOrder);
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setOrder(orderToEdit, editedOrder);
+
+        assertCommandSuccessWithTabChange(command, model, expectedMessage, expectedModel, UiTab.HOME);
+    }
+
+    @Test
+    public void execute_validIngredientAndOrderIndexFilteredList_addSuccessful() throws Exception {
+        showOrderAtIndex(model, INDEX_FIRST);
+
+        Ingredient validIngredient = new IngredientBuilder().build();
+        IngredientDescriptor validIngredientDescriptor = new IngredientDescriptorBuilder(validIngredient).build();
+        AddOrderIngredientCommand command = new AddOrderIngredientCommand(INDEX_FIRST, validIngredientDescriptor);
+        Order orderInFilteredList = model.getFilteredOrderList().get(INDEX_FIRST.getZeroBased());
+        RecipeIngredientList newRecipeIngredientList =
+                OrderUtil.addIngredientToIngredientList(orderInFilteredList, validIngredient);
+        Order editedOrder =
+                new OrderBuilder(orderInFilteredList).withRecipeIngredients(newRecipeIngredientList).build();
+
+        String expectedMessage = String.format(
+                AddOrderIngredientCommand.MESSAGE_ADD_ORDER_INGREDIENT_SUCCESS, validIngredient, editedOrder);
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        showOrderAtIndex(expectedModel, INDEX_FIRST);
+        expectedModel.setOrder(orderInFilteredList, editedOrder);
+
+        assertCommandSuccessWithTabChange(command, model, expectedMessage, expectedModel, UiTab.HOME);
+    }
+
+    @Test
+    public void execute_duplicateIngredient_failure() {
+        Order order = model.getFilteredOrderList().get(INDEX_FIRST.getZeroBased());
+        Ingredient duplicateIngredient = order.getRecipeIngredients().getIngredients().get(INDEX_FIRST.getZeroBased());
+        IngredientDescriptor validIngredientDescriptor = new IngredientDescriptorBuilder(duplicateIngredient).build();
+        AddOrderIngredientCommand command = new AddOrderIngredientCommand(INDEX_FIRST, validIngredientDescriptor);
+
+        assertCommandFailure(command, model, AddOrderIngredientCommand.MESSAGE_DUPLICATE_ORDER_INGREDIENT);
+    }
+
+    @Test
+    public void execute_duplicateOrder_failure() {
+        Ingredient firstIngredient = new IngredientBuilder().withIngredientName("Random name 1").build();
+        Ingredient secondIngredient = new IngredientBuilder().withIngredientName("Random name 2").build();
+        IngredientDescriptor secondIngredientDescriptor = new IngredientDescriptorBuilder(secondIngredient).build();
+        RecipeIngredientList firstIngredientList = new RecipeIngredientList(List.of(firstIngredient));
+        RecipeIngredientList secondIngredientList =
+                new RecipeIngredientList(List.of(firstIngredient, secondIngredient));
+        Order firstOrder = new OrderBuilder().withRecipeIngredients(firstIngredientList).build();
+        Order secondOrder = new OrderBuilder().withRecipeIngredients(secondIngredientList).build();
+        model.addOrder(firstOrder);
+        model.addOrder(secondOrder);
+
+        Index indexOfOrderToEdit = Index.fromZeroBased(model.getFilteredOrderList().indexOf(firstOrder));
+
+        AddOrderIngredientCommand command =
+                new AddOrderIngredientCommand(indexOfOrderToEdit, secondIngredientDescriptor);
+        assertCommandFailure(command, model, AddOrderCommand.MESSAGE_DUPLICATE_ORDER);
+    }
+
+    @Test
+    public void execute_invalidOrderIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredOrderList().size() + 1);
+        Ingredient validIngredient = new IngredientBuilder().build();
+        IngredientDescriptor validIngredientDescriptor = new IngredientDescriptorBuilder(validIngredient).build();
+        AddOrderIngredientCommand command = new AddOrderIngredientCommand(outOfBoundIndex, validIngredientDescriptor);
+
+        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidOrderIndexFilteredList_failure() {
+        showOrderAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getOrderList().size());
+
+        Ingredient validIngredient = new IngredientBuilder().build();
+        IngredientDescriptor validIngredientDescriptor = new IngredientDescriptorBuilder(validIngredient).build();
+        AddOrderIngredientCommand command = new AddOrderIngredientCommand(outOfBoundIndex, validIngredientDescriptor);
+
+        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final AddOrderIngredientCommand standardCommand = new AddOrderIngredientCommand(INDEX_FIRST, DESC_APPLE);
+
+        // same values -> returns true
+        IngredientDescriptor copyDescriptor = new IngredientDescriptor(DESC_APPLE);
+        AddOrderIngredientCommand commandWithSameValues = new AddOrderIngredientCommand(INDEX_FIRST, copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ListClientCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new AddOrderIngredientCommand(INDEX_SECOND, DESC_APPLE)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new AddOrderIngredientCommand(INDEX_FIRST, DESC_BEEF)));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/DeleteOrderIngredientCommandTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/order/DeleteOrderIngredientCommandTest.java
@@ -1,0 +1,121 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandFailure;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.assertCommandSuccessWithTabChange;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.showOrderAtIndex;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.OrderUtil.removeIngredientFromIngredientList;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_FIRST;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_SECOND;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalOrders.getTypicalAddressBook;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
+import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.client.ListClientCommand;
+import ay2122s1_cs2103t_w16_2.btbb.model.AddressBook;
+import ay2122s1_cs2103t_w16_2.btbb.model.Model;
+import ay2122s1_cs2103t_w16_2.btbb.model.ModelManager;
+import ay2122s1_cs2103t_w16_2.btbb.model.UserPrefs;
+import ay2122s1_cs2103t_w16_2.btbb.model.ingredient.Ingredient;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.RecipeIngredientList;
+import ay2122s1_cs2103t_w16_2.btbb.model.shared.GenericString;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.IngredientBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.ui.UiTab;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for DeleteOrderIngredientCommand.
+ */
+public class DeleteOrderIngredientCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validOrderIndex_success() throws NotFoundException {
+        Index editedOrderIndex = Index.fromZeroBased(model.getFilteredOrderList().size());
+        RecipeIngredientList recipeIngredientList = new RecipeIngredientList(List.of(new IngredientBuilder().build()));
+        Order orderToEdit = new OrderBuilder()
+                .withRecipeName(new GenericString("Random"))
+                .withRecipeIngredients(recipeIngredientList).build();
+        model.addOrder(orderToEdit);
+        Ingredient ingredientToDelete = new IngredientBuilder().build();
+
+        DeleteOrderIngredientCommand command =
+                new DeleteOrderIngredientCommand(INDEX_FIRST, editedOrderIndex);
+        RecipeIngredientList editedIngredientList = removeIngredientFromIngredientList(orderToEdit, ingredientToDelete);
+        Order editedOrder = new OrderBuilder(orderToEdit).withRecipeIngredients(editedIngredientList).build();
+
+        String expectedMessage = String.format(
+                DeleteOrderIngredientCommand.MESSAGE_DELETE_ORDER_INGREDIENT_SUCCESS, ingredientToDelete, editedOrder);
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setOrder(orderToEdit, editedOrder);
+
+        assertCommandSuccessWithTabChange(command, model, expectedMessage, expectedModel, UiTab.HOME);
+    }
+
+    @Test
+    public void execute_invalidOrderIndexFilteredList_throwsCommandException() {
+        showOrderAtIndex(model, INDEX_FIRST);
+
+        Index outOfBoundIndex = INDEX_SECOND;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getOrderList().size());
+
+        DeleteOrderIngredientCommand command = new DeleteOrderIngredientCommand(INDEX_FIRST, outOfBoundIndex);
+
+        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidOrderIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredOrderList().size() + 1);
+        DeleteOrderIngredientCommand command = new DeleteOrderIngredientCommand(INDEX_FIRST, outOfBoundIndex);
+
+        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidIngredientIndex_failure() {
+        Index targetOrderIndex = Index.fromZeroBased(model.getFilteredOrderList().size());
+        RecipeIngredientList recipeIngredientList = new RecipeIngredientList(List.of(new IngredientBuilder().build()));
+        Order orderToEdit = new OrderBuilder()
+                .withRecipeName(new GenericString("Random"))
+                .withRecipeIngredients(recipeIngredientList).build();
+        model.addOrder(orderToEdit);
+        Index outOfBoundIndex = Index.fromOneBased(recipeIngredientList.getIngredients().size() + 1);
+
+        DeleteOrderIngredientCommand command = new DeleteOrderIngredientCommand(outOfBoundIndex, targetOrderIndex);
+
+        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_INGREDIENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final DeleteOrderIngredientCommand standardCommand =
+                new DeleteOrderIngredientCommand(INDEX_FIRST, INDEX_SECOND);
+
+        // same values -> returns true
+        DeleteOrderIngredientCommand commandWithSameValues =
+                new DeleteOrderIngredientCommand(INDEX_FIRST, INDEX_SECOND);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ListClientCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new DeleteOrderIngredientCommand(INDEX_SECOND, INDEX_SECOND)));
+        assertFalse(standardCommand.equals(new DeleteOrderIngredientCommand(INDEX_FIRST, INDEX_FIRST)));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/util/CommandUtilTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/util/CommandUtilTest.java
@@ -1,0 +1,24 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.commands.util;
+
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.util.CommandUtil.makeOrderWithEditedIngredients;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
+import ay2122s1_cs2103t_w16_2.btbb.model.order.RecipeIngredientList;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.IngredientBuilder;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.OrderBuilder;
+
+public class CommandUtilTest {
+    @Test
+    public void makeOrderWithEditedIngredientsTest() {
+        RecipeIngredientList editedIngredients = new RecipeIngredientList(List.of(new IngredientBuilder().build()));
+        Order expectedOrder = new OrderBuilder().withRecipeIngredients(editedIngredients).build();
+
+        Order actualOrder = makeOrderWithEditedIngredients(editedIngredients, new OrderBuilder().build());
+        assertEquals(expectedOrder, actualOrder);
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/AddressBookParserTest.java
@@ -44,6 +44,7 @@ import ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient.EditIngredientComma
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient.FindIngredientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient.ListIngredientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderIngredientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.FindOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.ListOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
@@ -80,6 +81,21 @@ public class AddressBookParserTest {
         OrderDescriptor orderDescriptor = new OrderDescriptorBuilder(order).build();
         AddOrderCommand command = (AddOrderCommand) parser.parseCommand(OrderUtil.getAddCommand(order));
         assertEquals(new AddOrderCommand(orderDescriptor), command);
+    }
+
+    @Test
+    public void parseCommand_addOrderIngredient() throws Exception {
+        Ingredient ingredient = new IngredientBuilder().build();
+        IngredientDescriptor ingredientDescriptor = new IngredientDescriptorBuilder(ingredient).build();
+
+        AddOrderIngredientCommand command =
+                (AddOrderIngredientCommand) parser.parseCommand(AddOrderIngredientCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST.getOneBased() + " "
+                        + PREFIX_INGREDIENT_NAME + ingredient.getName().toString() + " "
+                        + PREFIX_INGREDIENT_QUANTITY + ingredient.getQuantity().toString() + " "
+                        + PREFIX_INGREDIENT_UNIT + ingredient.getUnit().toString()
+                );
+        assertEquals(new AddOrderIngredientCommand(INDEX_FIRST, ingredientDescriptor), command);
     }
 
     @Test

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/AddressBookParserTest.java
@@ -6,6 +6,7 @@ import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_CLI
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_CLIENT_EMAIL;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_CLIENT_NAME;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_CLIENT_PHONE;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_INDEX;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_NAME;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_QUANTITY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_QUANTITY_FROM;
@@ -45,6 +46,7 @@ import ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient.FindIngredientComma
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient.ListIngredientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderIngredientCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.DeleteOrderIngredientCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.FindOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.ListOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.ClientDescriptor;
@@ -96,6 +98,16 @@ public class AddressBookParserTest {
                         + PREFIX_INGREDIENT_UNIT + ingredient.getUnit().toString()
                 );
         assertEquals(new AddOrderIngredientCommand(INDEX_FIRST, ingredientDescriptor), command);
+    }
+
+    @Test
+    public void parseCommand_deleteOrderIngredient() throws Exception {
+        DeleteOrderIngredientCommand command =
+                (DeleteOrderIngredientCommand) parser.parseCommand(DeleteOrderIngredientCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST.getOneBased() + " "
+                        + PREFIX_INGREDIENT_INDEX + INDEX_FIRST.getOneBased()
+                );
+        assertEquals(new DeleteOrderIngredientCommand(INDEX_FIRST, INDEX_FIRST), command);
     }
 
     @Test

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/AddOrderCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/AddOrderCommandParserTest.java
@@ -3,7 +3,6 @@ package ay2122s1_cs2103t_w16_2.btbb.logic.parser.order;
 import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
-import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ADDRESS_DESC_IMRAN;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DEADLINE_DESC_DECEMBER;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.DEADLINE_DESC_MARCH;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INDEX_DESC_AMY;
@@ -19,14 +18,12 @@ import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INVALID
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INVALID_RECIPE_NAME_DESC;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.NAME_DESC_BOB;
-import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.NAME_DESC_IMRAN;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ORDER_PRICE_DESC_1;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ORDER_PRICE_DESC_2;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ORDER_QUANTITY_DESC_1;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.ORDER_QUANTITY_DESC_2;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PHONE_DESC_IMRAN;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.RECIPE_INGREDIENT_LIST_DESC_1;
@@ -130,20 +127,6 @@ class AddOrderCommandParserTest {
                         + RECIPE_NAME_DESC_LAKSA + RECIPE_INGREDIENT_LIST_DESC_2 + ORDER_PRICE_DESC_1
                         + ORDER_PRICE_DESC_2 + DEADLINE_DESC_MARCH + ORDER_QUANTITY_DESC_1 + ORDER_QUANTITY_DESC_2,
                 new AddOrderCommand(expectedOrderDescriptorWithoutClientIndex));
-
-        //=========== Without Client Index and ingredient list ========================================================
-
-        assertParseSuccess(parser, PHONE_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
-                        + RECIPE_NAME_DESC_CHICKEN_RICE + ORDER_PRICE_DESC_1 + DEADLINE_DESC_DECEMBER
-                        + ORDER_QUANTITY_DESC_1,
-                new AddOrderCommand(expectedOrderDescriptorWithoutClientIndexAndIngredientList));
-
-        //=========== Without Client Index and order quantity ========================================================
-
-        assertParseSuccess(parser, PHONE_DESC_IMRAN + NAME_DESC_IMRAN + ADDRESS_DESC_IMRAN
-                        + RECIPE_NAME_DESC_CHICKEN_RICE + RECIPE_INGREDIENT_LIST_DESC_1 + ORDER_PRICE_DESC_1
-                        + DEADLINE_DESC_DECEMBER,
-                new AddOrderCommand(expectedOrderDescriptorWithoutClientIndexAndOrderQuantity));
 
         //=========== With Client Index ===============================================================================
 

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/AddOrderIngredientCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/AddOrderIngredientCommandParserTest.java
@@ -1,0 +1,117 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INGREDIENT_NAME_DESC_APPLE;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INGREDIENT_NAME_DESC_BEEF;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INVALID_INDEX_DESC;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INVALID_INGREDIENT_NAME_DESC;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INVALID_QUANTITY_DESC;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INVALID_UNIT_DESC;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.QUANTITY_DESC_APPLE;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.QUANTITY_DESC_BEEF;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.UNIT_DESC_APPLE;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.UNIT_DESC_BEEF;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_INGREDIENT_NAME_BEEF;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_QUANTITY_BEEF;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.VALID_UNIT_BEEF;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_FIRST;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIngredients.BEEF;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderIngredientCommand;
+import ay2122s1_cs2103t_w16_2.btbb.logic.descriptors.IngredientDescriptor;
+import ay2122s1_cs2103t_w16_2.btbb.model.shared.GenericString;
+import ay2122s1_cs2103t_w16_2.btbb.model.shared.Quantity;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.IngredientDescriptorBuilder;
+
+public class AddOrderIngredientCommandParserTest {
+    private AddOrderIngredientCommandParser parser = new AddOrderIngredientCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Index targetIndex = INDEX_FIRST;
+        IngredientDescriptor expectedIngredientDescriptor = new IngredientDescriptorBuilder(BEEF).build();
+        String targetIndexDesc = targetIndex.getOneBased() + " ";
+
+        // whitespace only preamble
+        assertParseSuccess(parser, targetIndexDesc + INGREDIENT_NAME_DESC_BEEF + QUANTITY_DESC_BEEF
+                + UNIT_DESC_BEEF, new AddOrderIngredientCommand(targetIndex, expectedIngredientDescriptor));
+
+        // multiple ingredient names - last ingredient name accepted
+        assertParseSuccess(parser, targetIndexDesc
+                + INGREDIENT_NAME_DESC_APPLE + INGREDIENT_NAME_DESC_BEEF + QUANTITY_DESC_BEEF
+                + UNIT_DESC_BEEF, new AddOrderIngredientCommand(targetIndex, expectedIngredientDescriptor));
+
+        // multiple quantities - last quantity accepted
+        assertParseSuccess(parser, targetIndexDesc
+                + INGREDIENT_NAME_DESC_BEEF + QUANTITY_DESC_APPLE + QUANTITY_DESC_BEEF
+                + UNIT_DESC_BEEF, new AddOrderIngredientCommand(targetIndex, expectedIngredientDescriptor));
+
+        // multiple units - last unit accepted
+        assertParseSuccess(parser, targetIndexDesc
+                + INGREDIENT_NAME_DESC_BEEF + QUANTITY_DESC_BEEF + UNIT_DESC_APPLE
+                + UNIT_DESC_BEEF, new AddOrderIngredientCommand(targetIndex, expectedIngredientDescriptor));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String targetIndexDesc = INDEX_FIRST.getOneBased() + " ";
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderIngredientCommand.MESSAGE_USAGE);
+
+        // missing index
+        assertParseFailure(parser, VALID_INGREDIENT_NAME_BEEF + QUANTITY_DESC_BEEF + UNIT_DESC_BEEF,
+                expectedMessage);
+
+        // missing ingredient name prefix
+        assertParseFailure(parser, targetIndexDesc + VALID_INGREDIENT_NAME_BEEF + QUANTITY_DESC_BEEF + UNIT_DESC_BEEF,
+                expectedMessage);
+
+        // missing quantity prefix
+        assertParseFailure(parser, targetIndexDesc + INGREDIENT_NAME_DESC_BEEF + VALID_QUANTITY_BEEF + UNIT_DESC_BEEF,
+                expectedMessage);
+
+        // missing unit prefix
+        assertParseFailure(parser, targetIndexDesc + INGREDIENT_NAME_DESC_BEEF + QUANTITY_DESC_BEEF + VALID_UNIT_BEEF,
+                expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, targetIndexDesc + VALID_INGREDIENT_NAME_BEEF + VALID_QUANTITY_BEEF + VALID_UNIT_BEEF,
+                expectedMessage);
+
+        // all arguments missing
+        assertParseFailure(parser, VALID_INGREDIENT_NAME_BEEF + VALID_QUANTITY_BEEF + VALID_UNIT_BEEF,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        String targetIndexDesc = INDEX_FIRST.getOneBased() + " ";
+
+        // invalid ingredient index
+        assertParseFailure(parser, INVALID_INDEX_DESC
+                + INGREDIENT_NAME_DESC_BEEF + QUANTITY_DESC_BEEF + UNIT_DESC_BEEF,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderIngredientCommand.MESSAGE_USAGE));
+
+        // invalid ingredient name
+        assertParseFailure(parser, targetIndexDesc + INVALID_INGREDIENT_NAME_DESC + QUANTITY_DESC_BEEF + UNIT_DESC_BEEF,
+                GenericString.getMessageConstraints("Name"));
+
+        // invalid quantity
+        assertParseFailure(parser, targetIndexDesc + INGREDIENT_NAME_DESC_BEEF + INVALID_QUANTITY_DESC + UNIT_DESC_BEEF,
+                Quantity.MESSAGE_CONSTRAINTS);
+
+        // invalid unit
+        assertParseFailure(parser, targetIndexDesc + INGREDIENT_NAME_DESC_BEEF + QUANTITY_DESC_BEEF + INVALID_UNIT_DESC,
+                GenericString.getMessageConstraints("Unit"));
+
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, targetIndexDesc
+                        + INVALID_INGREDIENT_NAME_DESC + INVALID_QUANTITY_DESC + UNIT_DESC_BEEF,
+                GenericString.getMessageConstraints("Name"));
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/DeleteOrderIngredientCommandParserTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/logic/parser/order/DeleteOrderIngredientCommandParserTest.java
@@ -1,0 +1,39 @@
+package ay2122s1_cs2103t_w16_2.btbb.logic.parser.order;
+
+import static ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INGREDIENT_INDEX_DESC_FIRST;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandTestUtil.INVALID_INGREDIENT_INDEX_DESC_FIRST;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.ParserUtil.MESSAGE_INVALID_INDEX;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.Test;
+
+import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.DeleteOrderIngredientCommand;
+
+public class DeleteOrderIngredientCommandParserTest {
+    private DeleteOrderIngredientCommandParser parser = new DeleteOrderIngredientCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteOrderIngredientCommand() {
+        assertParseSuccess(parser, "1 " + INGREDIENT_INDEX_DESC_FIRST,
+                new DeleteOrderIngredientCommand(INDEX_FIRST, INDEX_FIRST));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // Invalid order index
+        assertParseFailure(parser, "a " + INGREDIENT_INDEX_DESC_FIRST,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteOrderIngredientCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "-100" + INGREDIENT_INDEX_DESC_FIRST,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteOrderIngredientCommand.MESSAGE_USAGE));
+
+        // Invalid ingredient index
+        assertParseFailure(parser, "1 " + INVALID_INGREDIENT_INDEX_DESC_FIRST, MESSAGE_INVALID_INDEX);
+
+        // Both args invalid -> invalid ingredient index message shown
+        assertParseFailure(parser, "-1 " + INVALID_INGREDIENT_INDEX_DESC_FIRST, MESSAGE_INVALID_INDEX);
+    }
+}

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/order/RecipeIngredientListTest.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/model/order/RecipeIngredientListTest.java
@@ -1,6 +1,7 @@
 package ay2122s1_cs2103t_w16_2.btbb.model.order;
 
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.Assert.assertThrows;
+import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIngredients.APPLE;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIngredients.AVOCADO;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIngredients.BREAD;
 import static ay2122s1_cs2103t_w16_2.btbb.testutil.TypicalIngredients.BUTTER;
@@ -12,10 +13,39 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import ay2122s1_cs2103t_w16_2.btbb.model.ingredient.Ingredient;
+import ay2122s1_cs2103t_w16_2.btbb.testutil.IngredientBuilder;
+
 class RecipeIngredientListTest {
+    private final RecipeIngredientList recipeIngredientList = new RecipeIngredientList(new ArrayList<>());
     @Test
     public void constructor_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new RecipeIngredientList(null));
+    }
+
+    @Test
+    public void contains_nullIngredient_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> recipeIngredientList.contains(null));
+    }
+
+    @Test
+    public void contains_ingredientNotInList_returnsFalse() {
+        assertFalse(recipeIngredientList.contains(APPLE));
+    }
+
+    @Test
+    public void contains_ingredientInList_returnsTrue() {
+        recipeIngredientList.getIngredients().add(APPLE);
+        assertTrue(recipeIngredientList.contains(APPLE));
+    }
+
+    @Test
+    public void contains_ingredientWithSameIdentityFieldsInList_returnsTrue() {
+        recipeIngredientList.getIngredients().add(APPLE);
+        Ingredient appleWithEditedSameUnit = new IngredientBuilder(APPLE).withUnit("whole").build();
+        Ingredient appleWithEditedDifferentQuantity = new IngredientBuilder(APPLE).withQuantity("1000").build();
+        assertTrue(recipeIngredientList.contains(appleWithEditedSameUnit));
+        assertTrue(recipeIngredientList.contains(appleWithEditedDifferentQuantity));
     }
 
     @Test

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/OrderUtil.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/OrderUtil.java
@@ -37,6 +37,20 @@ public class OrderUtil {
         return new RecipeIngredientList(newIngredients);
     }
 
+    /**
+     * Removes ingredient from a copy of an ingredient list of an order.
+     *
+     * @param order Order to get the original ingredient list from.
+     * @param ingredient Ingredient to remove from the ingredient list.
+     * @return New ingredient list.
+     */
+    public static RecipeIngredientList removeIngredientFromIngredientList(Order order, Ingredient ingredient) {
+        RecipeIngredientList editedRecipeIngredientList = order.getRecipeIngredients();
+        List<Ingredient> newIngredients = new ArrayList<>(editedRecipeIngredientList.getIngredients());
+        newIngredients.remove(ingredient);
+        return new RecipeIngredientList(newIngredients);
+    }
+
     public static String getAddCommand(Order order) {
         return AddOrderCommand.COMMAND_WORD + " " + getOrderDetails(order);
     }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/OrderUtil.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/OrderUtil.java
@@ -9,10 +9,13 @@ import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_ORD
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_RECIPE_INGREDIENT;
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_RECIPE_NAME;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.order.AddOrderCommand;
 import ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.Prefix;
+import ay2122s1_cs2103t_w16_2.btbb.model.ingredient.Ingredient;
 import ay2122s1_cs2103t_w16_2.btbb.model.order.Order;
 import ay2122s1_cs2103t_w16_2.btbb.model.order.RecipeIngredientList;
 
@@ -20,6 +23,20 @@ import ay2122s1_cs2103t_w16_2.btbb.model.order.RecipeIngredientList;
  * A utility class for Order.
  */
 public class OrderUtil {
+    /**
+     * Adds ingredient to a copy of an ingredient list of an order.
+     *
+     * @param order Order to get the original ingredient list from.
+     * @param ingredient Ingredient to add to the ingredient list.
+     * @return New ingredient list.
+     */
+    public static RecipeIngredientList addIngredientToIngredientList(Order order, Ingredient ingredient) {
+        RecipeIngredientList editedRecipeIngredientList = order.getRecipeIngredients();
+        List<Ingredient> newIngredients = new ArrayList<>(editedRecipeIngredientList.getIngredients());
+        newIngredients.add(ingredient);
+        return new RecipeIngredientList(newIngredients);
+    }
+
     public static String getAddCommand(Order order) {
         return AddOrderCommand.COMMAND_WORD + " " + getOrderDetails(order);
     }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStub.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStub.java
@@ -137,6 +137,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void setOrder(Order target, Order editedOrder) throws NotFoundException {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public ObservableList<Order> getFilteredOrderList() {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStub.java
+++ b/src/test/java/ay2122s1_cs2103t_w16_2/btbb/testutil/stubs/ModelStub.java
@@ -95,6 +95,11 @@ public class ModelStub implements Model {
         throw new AssertionError("This method should not be called.");
     }
 
+    @Override
+    public void addIngredientQuantity(Ingredient target, Quantity multiplier) {
+        throw new AssertionError("This method should not be called.");
+    }
+
     public boolean hasIngredient(Ingredient ingredient) {
         throw new AssertionError("This method should not be called.");
     }


### PR DESCRIPTION
Tackles part of #89 
- To be merged in after the base edit order ingredient (because some methods used are shared)
- Does not include tests for the shared methods mentioned above