### PR TITLE
Add ingredient command logging

### DIFF
--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/ingredient/AddIngredientCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/ingredient/AddIngredientCommand.java
@@ -5,6 +5,10 @@ import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_ING
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_UNIT;
 import static java.util.Objects.requireNonNull;
 
+import java.util.logging.Logger;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.LogsCenter;
+import ay2122s1_cs2103t_w16_2.btbb.commons.util.JsonUtil;
 import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.Command;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
@@ -32,6 +36,8 @@ public class AddIngredientCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New ingredient added: %1$s";
     public static final String MESSAGE_DUPLICATE_INGREDIENT = "This ingredient already exists in your inventory.";
 
+    private static final Logger logger = LogsCenter.getLogger(JsonUtil.class);
+
     private final IngredientDescriptor ingredientDescriptor;
 
     /**
@@ -53,6 +59,8 @@ public class AddIngredientCommand extends Command {
      */
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        logger.info("Executing " + AddIngredientCommand.class.getSimpleName());
+
         requireNonNull(model);
         Ingredient ingredient = ingredientDescriptor.toModelType();
 

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/ingredient/DeleteIngredientCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/ingredient/DeleteIngredientCommand.java
@@ -3,9 +3,12 @@ package ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.logging.Logger;
 
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.LogsCenter;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
+import ay2122s1_cs2103t_w16_2.btbb.commons.util.JsonUtil;
 import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
 import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.Command;
@@ -27,6 +30,8 @@ public class DeleteIngredientCommand extends Command {
 
     public static final String MESSAGE_DELETE_INGREDIENT_SUCCESS = "Deleted Ingredient: %1$s";
 
+    private static final Logger logger = LogsCenter.getLogger(JsonUtil.class);
+
     private final Index targetIndex;
 
     public DeleteIngredientCommand(Index targetIndex) {
@@ -35,6 +40,8 @@ public class DeleteIngredientCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        logger.info("Executing " + DeleteIngredientCommand.class.getSimpleName());
+
         requireNonNull(model);
         List<Ingredient> lastShownList = model.getFilteredIngredientList();
 

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/ingredient/EditIngredientCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/ingredient/EditIngredientCommand.java
@@ -8,9 +8,12 @@ import static ay2122s1_cs2103t_w16_2.btbb.model.Model.PREDICATE_SHOW_ALL_INGREDI
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.logging.Logger;
 
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.LogsCenter;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.index.Index;
+import ay2122s1_cs2103t_w16_2.btbb.commons.util.JsonUtil;
 import ay2122s1_cs2103t_w16_2.btbb.exception.CommandException;
 import ay2122s1_cs2103t_w16_2.btbb.exception.NotFoundException;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.Command;
@@ -38,6 +41,8 @@ public class EditIngredientCommand extends Command {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_INGREDIENT = "This ingredient already exists in the address book.";
 
+    private static final Logger logger = LogsCenter.getLogger(JsonUtil.class);
+
     private final Index index;
     private final IngredientDescriptor editIngredientDescriptor;
 
@@ -54,6 +59,8 @@ public class EditIngredientCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        logger.info("Executing " + EditIngredientCommand.class.getSimpleName());
+
         requireNonNull(model);
         List<Ingredient> lastShownList = model.getFilteredIngredientList();
 

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/ingredient/FindIngredientCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/ingredient/FindIngredientCommand.java
@@ -7,7 +7,11 @@ import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_ING
 import static ay2122s1_cs2103t_w16_2.btbb.logic.parser.util.CliSyntax.PREFIX_INGREDIENT_UNIT;
 import static java.util.Objects.requireNonNull;
 
+import java.util.logging.Logger;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.LogsCenter;
 import ay2122s1_cs2103t_w16_2.btbb.commons.core.Messages;
+import ay2122s1_cs2103t_w16_2.btbb.commons.util.JsonUtil;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.Command;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
@@ -39,6 +43,8 @@ public class FindIngredientCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_INGREDIENT_NAME + "corn"
             + " " + PREFIX_INGREDIENT_QUANTITY + "30 20 15";
 
+    private static final Logger logger = LogsCenter.getLogger(JsonUtil.class);
+
     private final PredicateCollection<Ingredient> predicateCollection;
 
     public FindIngredientCommand(PredicateCollection<Ingredient> predicateCollection) {
@@ -47,6 +53,8 @@ public class FindIngredientCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
+        logger.info("Executing " + FindIngredientCommand.class.getSimpleName());
+
         requireNonNull(model);
         model.updateFilteredIngredientList(predicateCollection);
         return new CommandResult(

--- a/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/ingredient/ListIngredientCommand.java
+++ b/src/main/java/ay2122s1_cs2103t_w16_2/btbb/logic/commands/ingredient/ListIngredientCommand.java
@@ -3,6 +3,10 @@ package ay2122s1_cs2103t_w16_2.btbb.logic.commands.ingredient;
 import static ay2122s1_cs2103t_w16_2.btbb.model.Model.PREDICATE_SHOW_ALL_INGREDIENTS;
 import static java.util.Objects.requireNonNull;
 
+import java.util.logging.Logger;
+
+import ay2122s1_cs2103t_w16_2.btbb.commons.core.LogsCenter;
+import ay2122s1_cs2103t_w16_2.btbb.commons.util.JsonUtil;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.Command;
 import ay2122s1_cs2103t_w16_2.btbb.logic.commands.CommandResult;
 import ay2122s1_cs2103t_w16_2.btbb.model.Model;
@@ -16,8 +20,12 @@ public class ListIngredientCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all ingredients";
 
+    private static final Logger logger = LogsCenter.getLogger(JsonUtil.class);
+
     @Override
     public CommandResult execute(Model model) {
+        logger.info("Executing " + ListIngredientCommand.class.getSimpleName());
+
         requireNonNull(model);
         model.updateFilteredIngredientList(PREDICATE_SHOW_ALL_INGREDIENTS);
         return new CommandResult(MESSAGE_SUCCESS, UiTab.INVENTORY);


### PR DESCRIPTION
Part of #110 

- Uses `.getSimpleName()` instead of `.getName()` so that package name will not be shown
- Seems repetitive (every class has its own private logger instance & the log message is explicitly written each time) but this is the current convention for logging in the app