### PR TITLE
Fix find examples in User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -324,8 +324,7 @@ Format: `find-i [in/NAME] [iq/QUANTITY] [iqf/QUANTITY_FROM] [iqt/QUANTITY_TO] [i
 **Examples:**
 * `find-i in/co` Find ingredients with names containing 'co'. E.g. **Co**rn, Ba**co**n.
 * `find-i iq/20 33` Find ingredients with quantities equal to 20 or 33.
-* `find-i in/co eg iqf/7 iqt/19 iu/g` Find ingredients with name and unit containing at least 1 of the
-  keywords for each prefix, and quantity in the specified range. 
+* `find-i in/co eg iqf/7 iqt/19 iu/g` Find ingredients with name and unit containing at least 1 of the keywords for each prefix, and quantity in the specified range.
   These ingredients with the following details will be matched:
   * **Co**rn **7** **g**rams
   * **Eg**g **19** k**g**


### PR DESCRIPTION
Resolves part of https://github.com/AY2122S1-CS2103T-W16-2/tp/issues/142.

Changes made:
* Bold parts that match
* Standardise find-c and find-i with find-o

You can view the [User guide](https://eunicesim142.github.io/tp/UserGuide.html).